### PR TITLE
treat @filters as possible array of values

### DIFF
--- a/lib/json_api_client/query/builder.rb
+++ b/lib/json_api_client/query/builder.rb
@@ -115,7 +115,7 @@ module JsonApiClient
       end
 
       def filter_params
-        @filters.empty? ? {} : {filter: @filters}
+        @filters.empty? ? {} : { filter: @filters.inject({}) { |m, (k, v)| m[k] = v.respond_to?(:each) ? v.join(',') : v; m } }
       end
 
       def order_params


### PR DESCRIPTION
Should turn:

```
@filters = {'key' => ['val1', 'val2']}
```

into comma delimited values:

```
@filters = {'key' => 'val1,val2'}
```
