### PR TITLE
Exclude path params from attributes hash

### DIFF
--- a/lib/json_api_client/resource.rb
+++ b/lib/json_api_client/resource.rb
@@ -447,8 +447,15 @@ module JsonApiClient
       self.class.associations.detect{|association| association.attr_name == name}
     end
 
+    def non_serializing_attributes
+      [
+        self.class.read_only_attributes,
+        self.class.prefix_params.map(&:to_s)
+      ].flatten
+    end
+
     def attributes_for_serialization
-      attributes.except(*self.class.read_only_attributes).slice(*changed)
+      attributes.except(*non_serializing_attributes).slice(*changed)
     end
 
     def relationships_for_serialization

--- a/test/unit/serializing_test.rb
+++ b/test/unit/serializing_test.rb
@@ -6,6 +6,10 @@ class SerializingTest < MiniTest::Test
     self.read_only_attributes += ['foo']
   end
 
+  class NestedResource < TestResource
+    belongs_to :bar
+  end
+
   class CustomSerializerAttributes < TestResource
 
     protected
@@ -222,6 +226,20 @@ class SerializingTest < MiniTest::Test
       "id" => 1234,
       "attributes" => {
         "qwer" => "asdf"
+      }
+    }
+
+    assert_equal expected, resource.as_json_api
+  end
+
+  def test_ensure_nested_path_params_not_serialized
+    resource = NestedResource.new(foo: 'bar', id: 1, bar_id: 99)
+
+    expected = {
+      'id' => 1,
+      'type' => "nested_resources",
+      'attributes' => {
+        'foo' => 'bar'
       }
     }
 


### PR DESCRIPTION
Currently path params (e.g. parent attribute ids for nested attributes) are included in the `attributes` hash when serialized. This causes problems when APIs do not expect it. This patch resolves the issue by excluding these with an easy-to-overwrite method on `Resource`.
