### PR TITLE
Default attributes should defer to actual attributes

### DIFF
--- a/lib/json_api_client/resource.rb
+++ b/lib/json_api_client/resource.rb
@@ -281,7 +281,7 @@ module JsonApiClient
           set_attribute(association.attr_name, association.parse(params[association.attr_name.to_s]))
         end
       end
-      self.attributes = params.merge(self.class.default_attributes)
+      self.attributes = params.reverse_merge(self.class.default_attributes)
       self.class.schema.each_property do |property|
         attributes[property.name] = property.default unless attributes.has_key?(property.name) || property.default.nil?
       end


### PR DESCRIPTION
Reversing this merge allows attributes from the params to override the defaults set with this method; this allows users to override `default_attributes` with defaults with the expected behavior.
