### PR TITLE
Extract adding errors into a method when saving a resource

### DIFF
--- a/lib/json_api_client/resource.rb
+++ b/lib/json_api_client/resource.rb
@@ -401,11 +401,7 @@ module JsonApiClient
 
       if last_result_set.has_errors?
         last_result_set.errors.each do |error|
-          if error.source_parameter
-            errors.add(self.class.key_formatter.unformat(error.source_parameter), error.title || error.detail)
-          else
-            errors.add(:base, error.title || error.detail)
-          end
+          add_error(error)
         end
         false
       else
@@ -439,6 +435,14 @@ module JsonApiClient
     end
 
     protected
+
+    def add_error(error)
+      if error.source_parameter
+        errors.add(self.class.key_formatter.unformat(error.source_parameter), error.title || error.detail)
+      else
+        errors.add(:base, error.title || error.detail)
+      end
+    end
 
     def method_missing(method, *args)
       association = association_for(method)


### PR DESCRIPTION
I want to customize the way the errors are added when saving a resource. I want to do some i18n things instead of directly using what's been returned by the server side.

Extracting that specific code into a `Resource#add_error` method enables me to do some clean monkey-patching (instead of copying the whole `save` method).