### PR TITLE
support "code" attribute of error messages

### DIFF
--- a/lib/json_api_client/resource.rb
+++ b/lib/json_api_client/resource.rb
@@ -411,11 +411,7 @@ module JsonApiClient
 
       if last_result_set.has_errors?
         last_result_set.errors.each do |error|
-          if error.source_parameter
-            errors.add(self.class.key_formatter.unformat(error.source_parameter), error.title || error.detail)
-          else
-            errors.add(:base, error.title || error.detail)
-          end
+          add_error(error)
         end
         false
       else
@@ -449,6 +445,20 @@ module JsonApiClient
     end
 
     protected
+
+    def add_error(error)
+      if error.source_parameter
+        error_attribute = self.class.key_formatter.unformat(error.source_parameter)
+
+        if error.code && respond_to?(error_attribute)
+          errors.add(error_attribute, error.code.to_sym)
+        else
+          errors.add(error_attribute, error.title || error.detail)
+        end
+      else
+        errors.add(:base, error.title || error.detail)
+      end
+    end
 
     def method_missing(method, *args)
       association = association_for(method)

--- a/test/unit/server_side_error_test.rb
+++ b/test/unit/server_side_error_test.rb
@@ -38,11 +38,26 @@ class ServerSideErrorTest < MiniTest::Test
         .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
           errors: [{source: {pointer: "/data/attributes/email-address"}, title: "Email address is invalid"}]
         }.to_json)
-      
+
       user = User.create(name: 'Bob', email_address: 'invalid email')
       assert !user.persisted?
       assert user.errors.present?
       assert_equal ["Email address is invalid"], user.errors[:email_address]
+    end
+  end
+
+  def test_can_handle_key_formatted_attribute_validation_codes
+    with_altered_config(User, :json_key_format => :dasherized_key) do
+      stub_request(:post, "http://example.com/users")
+        .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
+          errors: [{source: {pointer: "/data/attributes/email-address"}, title: "Email address is invalid", code: "invalid"}]
+        }.to_json)
+
+      user = User.create(name: 'Bob', email_address: 'invalid email')
+      assert !user.persisted?
+      assert user.errors.present?
+      assert_equal ["is invalid"], user.errors[:email_address]
+      assert_equal [{error: :invalid}], user.errors.details[:email_address] if user.errors.respond_to?(:details)
     end
   end
 


### PR DESCRIPTION
- codes added to errors as symbols
- can be mapped with i18n by clients

The codes are "taken" or "invalid" and can be mapped to different languages with Rails i18n.