### PR TITLE
Inherit custom headers

### DIFF
--- a/lib/json_api_client/resource.rb
+++ b/lib/json_api_client/resource.rb
@@ -156,7 +156,9 @@ module JsonApiClient
       #
       # @return [Hash] Headers
       def custom_headers
-        _header_store.to_h
+        return _header_store.to_h if superclass == Object
+
+        superclass.custom_headers.merge(_header_store.to_h)
       end
 
       # Returns the requestor for this resource class

--- a/test/unit/custom_header_test.rb
+++ b/test/unit/custom_header_test.rb
@@ -59,6 +59,24 @@ class CustomHeaderTest < MiniTest::Test
     end
   end
 
+  def test_custom_headers_are_inherited
+    stub_request(:get, "http://example.com/custom_header_resources/1")
+      .with(headers: {"X-My-Header" => "asdf"})
+      .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
+        data: {
+          type: "custom_header_resources",
+          id: "1",
+          attributes: {
+            title: "Rails is Omakase"
+          }
+        }
+      }.to_json)
+
+    JsonApiClient::Resource.with_headers(x_my_header: "asdf") do
+      CustomHeaderResource.find(1)
+    end
+  end
+
   def test_multiple_threads
     thread_count = 10
 


### PR DESCRIPTION
This PR resolves #255 by making `custom_headers` inherit from ancestors.

I think this should be the expected behaviour ~~but sadly is not backwards compatible~~. Should be backwards compatible.
Would love to hear some feedback 😃 

```ruby
class ArticleResource < JsonApiClient::Resource
end

class ApplicationController
  around_action :configure_json_api_client

  def index
    # will request articles with the authorization header set
     articles = ArticleResource.all
  end

  private

  def configure_json_api_client
    JsonApiClient::Resource.with_headers(authorization: 'Bearer TOKEN') { yield }
  end
end
```