### PR TITLE
Dynamic attribute optimizations

### DIFF
--- a/lib/json_api_client/helpers/dynamic_attributes.rb
+++ b/lib/json_api_client/helpers/dynamic_attributes.rb
@@ -24,7 +24,7 @@ module JsonApiClient
       end
 
       def respond_to_missing?(method, include_private = false)
-        if has_attribute?(method) || (method.to_s =~ /^(.*)=$/)
+        if has_attribute?(method) || method.to_s.end_with?('=')
           true
         else
           super
@@ -42,8 +42,8 @@ module JsonApiClient
 
         normalized_method = safe_key_formatter.unformat(method.to_s)
 
-        if normalized_method =~ /^(.*)=$/
-          set_attribute($1, args.first)
+        if normalized_method.end_with?('=')
+          set_attribute(normalized_method[0..-2], args.first)
         else
           super
         end

--- a/lib/json_api_client/helpers/dynamic_attributes.rb
+++ b/lib/json_api_client/helpers/dynamic_attributes.rb
@@ -24,7 +24,7 @@ module JsonApiClient
       end
 
       def respond_to_missing?(method, include_private = false)
-        if (method.to_s =~ /^(.*)=$/) || has_attribute?(method)
+        if has_attribute?(method) || (method.to_s =~ /^(.*)=$/)
           true
         else
           super
@@ -38,6 +38,8 @@ module JsonApiClient
       protected
 
       def method_missing(method, *args, &block)
+        return attributes[method] if has_attribute?(method)
+
         normalized_method = if key_formatter
                               key_formatter.unformat(method.to_s)
                             else
@@ -46,8 +48,6 @@ module JsonApiClient
 
         if normalized_method =~ /^(.*)=$/
           set_attribute($1, args.first)
-        elsif has_attribute?(method)
-          attributes[method]
         else
           super
         end

--- a/lib/json_api_client/helpers/dynamic_attributes.rb
+++ b/lib/json_api_client/helpers/dynamic_attributes.rb
@@ -38,7 +38,14 @@ module JsonApiClient
       protected
 
       def method_missing(method, *args, &block)
-        return attributes[method] if has_attribute?(method)
+        if has_attribute?(method)
+          self.class.class_eval do
+            define_method(method) do
+              attributes[method]
+            end
+          end
+          return send(method)
+        end
 
         normalized_method = safe_key_formatter.unformat(method.to_s)
 

--- a/lib/json_api_client/helpers/dynamic_attributes.rb
+++ b/lib/json_api_client/helpers/dynamic_attributes.rb
@@ -40,11 +40,7 @@ module JsonApiClient
       def method_missing(method, *args, &block)
         return attributes[method] if has_attribute?(method)
 
-        normalized_method = if key_formatter
-                              key_formatter.unformat(method.to_s)
-                            else
-                              method.to_s
-                            end
+        normalized_method = safe_key_formatter.unformat(method.to_s)
 
         if normalized_method =~ /^(.*)=$/
           set_attribute($1, args.first)
@@ -61,8 +57,18 @@ module JsonApiClient
         attributes[name] = value
       end
 
+      def safe_key_formatter
+        @safe_key_formatter ||= (key_formatter || DefaultKeyFormatter.new)
+      end
+
       def key_formatter
         self.class.respond_to?(:key_formatter) && self.class.key_formatter
+      end
+
+      class DefaultKeyFormatter
+        def unformat(method)
+          method.to_s
+        end
       end
 
     end

--- a/test/unit/benchmark_dynamic_attributes_test.rb
+++ b/test/unit/benchmark_dynamic_attributes_test.rb
@@ -1,0 +1,42 @@
+require 'test_helper'
+require 'benchmark'
+
+class BenchmarkDynamicAttributesTest < MiniTest::Test
+  def test_can_parse_global_meta_data
+    stub_request(:get, "http://example.com/articles/1")
+      .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
+        data: {
+          type: "articles",
+          id: "1",
+          attributes: {
+            title: "Rails is Omakase"
+          }
+        },
+        meta: {
+          copyright: "Copyright 2015 Example Corp.",
+          authors: [
+            "Yehuda Katz",
+            "Steve Klabnik",
+            "Dan Gebhardt"
+          ]
+        },
+      }.to_json)
+
+    article = Article.find(1).first
+
+    assert_equal "Rails is Omakase", article.title
+    assert_equal "1", article.id
+
+    n = 10_000
+    puts
+    Benchmark.bm do |x|
+      x.report('read: ') { n.times { article.title; article.id } }
+      x.report('write:') do
+        n.times do
+          article.title = 'New title'
+          article.better_title = 'Better title'
+        end
+      end
+    end
+  end
+end

--- a/test/unit/resource_test.rb
+++ b/test/unit/resource_test.rb
@@ -73,13 +73,13 @@ class ResourceTest < MiniTest::Test
     end
 
     with_altered_config(Article, :json_key_format => :underscored_key) do
-      article = Article.new("foo-bar" => "baz")
+      article = Article.new("foo-bam" => "baz")
       # Does not recognize dasherized attributes, fall back to hash syntax
-      refute article.respond_to? :foo_bar
-      assert_equal("baz", article.send("foo-bar"))
-      assert_equal("baz", article.send(:"foo-bar"))
-      assert_equal("baz", article["foo-bar"])
-      assert_equal("baz", article[:"foo-bar"])
+      refute article.respond_to? :foo_bam
+      assert_equal("baz", article.send("foo-bam"))
+      assert_equal("baz", article.send(:"foo-bam"))
+      assert_equal("baz", article["foo-bam"])
+      assert_equal("baz", article[:"foo-bam"])
     end
   end
 


### PR DESCRIPTION
I was profiling some code that handles json_api_client results, and makes a lot of use of the dynamic attribute methods. I noticed that if I just implemented my own getter methods:

```ruby
class Article
  def title
    attributes[:title]
  end
end
```

...then it got surprisingly faster.

I looked at the source, and spotted a few optimizations I could make. Here are 4, each with before/after benchmark times (the benchmark code is committed here as a unit test, which we can yank or move before this is merged).

The only commit without benchmark times is the change to use `end_with?('=')` instead of `=~ /^(.*)=$/`, because it didn't actually speed it up. I committed it here as a curiosity; because I think `ends_with?('=')` is clearer than the regex; and because I've seen people say that it's faster, so this heads off the conversation.

Probably the most controversial optimization is the last one: to auto-define getter methods for attributes from `DynamicAttributes#method_missing`. This is a significant speed-up: basically, we'll never have to run that method_missing logic again for that method name. Since the classes already respond to those methods, and handle those messages in an equivalent (but slower) way, this seems OK to me. Also, I don't think we have to worry about overwriting client code, because by definition, if `#method_missing` is running, then they didn't define this one.

Here's the overall benchmark difference, from the first commit (which only adds the benchmark unit test), to the last (with the 4 optimizations):

Before:
```
       user     system      total        real
read:   1.090000   0.010000   1.100000 (  1.091464)
write:  1.130000   0.000000   1.130000 (  1.136750)
```

After:
```
       user     system      total        real
read:   0.020000   0.000000   0.020000 (  0.016366)
write:  0.690000   0.000000   0.690000 (  0.687914)
```