### PR TITLE
Fix custom type comment to use TypeFactory

### DIFF
--- a/lib/json_api_client/schema.rb
+++ b/lib/json_api_client/schema.rb
@@ -67,11 +67,11 @@ module JsonApiClient
       #      end
       #   end
       #
-      #   JsonApiClient::Schema::Types.register money: MyMoneyCaster
+      #   JsonApiClient::Schema::TypeFactory.register money: MyMoneyCaster
       #
       # You can setup several at once:
       #
-      #   JsonApiClient::Schema::Types.register money: MyMoneyCaster,
+      #   JsonApiClient::Schema::TypeFactory.register money: MyMoneyCaster,
       #                                         date: MyJsonDateTypeCaster
       #
       #


### PR DESCRIPTION
The documentation to add a custom type is wrong and the example does not work.

The method `register` is on `TypeFactory` and not on the `Type` module.