### PR TITLE
#278 updating faraday to fix issue when param value is an empty array

### DIFF
--- a/json_api_client.gemspec
+++ b/json_api_client.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.summary = 'Build client libraries compliant with specification defined by jsonapi.org'
 
   s.add_dependency "activesupport", '>= 3.2.0'
-  s.add_dependency "faraday", '~> 0.9'
+  s.add_dependency "faraday", ['~> 0.15', '>= 0.15.2']
   s.add_dependency "faraday_middleware", '~> 0.9'
   s.add_dependency "addressable", '~> 2.2'
   s.add_dependency "activemodel", '>= 3.2.0'

--- a/test/unit/query_builder_test.rb
+++ b/test/unit/query_builder_test.rb
@@ -169,4 +169,29 @@ class QueryBuilderTest < MiniTest::Test
     Article.select({comments: 'author,text'}, :tags).to_a
   end
 
+  def test_can_specify_array_filter_value
+    stub_request(:get, "http://example.com/articles?filter%5Bauthor.id%5D%5B0%5D=foo&filter%5Bauthor.id%5D%5B1%5D=bar")
+        .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
+            data: []
+        }.to_json)
+    Article.where(:'author.id' => ['foo', 'bar']).to_a
+  end
+
+  def test_can_specify_empty_array_filter_value
+    stub_request(:get, "http://example.com/articles?filter%5Bauthor.id%5D%5B0%5D")
+        .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
+            data: []
+        }.to_json)
+    Article.where(:'author.id' => []).to_a
+  end
+
+  def test_can_specify_empty_string_filter_value
+    stub_request(:get, "http://example.com/articles")
+        .with(query: {filter: {:'author.id' => ''}})
+        .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
+            data: []
+        }.to_json)
+    Article.where(:'author.id' => '').to_a
+  end
+
 end


### PR DESCRIPTION
fix #278 

Handling of empty array as parameter value was fixed in faraday with lostisland/faraday/pull/801 

`jsonapi` spec says that filters implementation can be different so we need to support all cases - even sending an empty array