### PR TITLE
allow to send fields and/or includes on create/update resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,23 @@ results = Article.includes(:author, :comments => :author).find(1)
 
 # should not have to make additional requests to the server
 authors = results.map(&:author)
+
+# makes POST request to /articles?include=author,comments.author
+article = Article.new(title: 'New one').request_includes(:author, :comments => :author)
+article.save
+
+# makes PATCH request to /articles/1?include=author,comments.author
+article = Article.find(1)
+article.title = 'Changed'
+article.request_includes(:author, :comments => :author)
+article.save
+
+# request includes will be cleared if response is successful
+# to avoid this `keep_request_params` class attribute can be used
+Article.keep_request_params = true
+
+# to clear request_includes use
+article.reset_request_includes!
 ```
 
 ## Sparse Fieldsets
@@ -217,6 +234,24 @@ article.created_at
 # or you can use fieldsets from multiple resources
 # makes request to /articles?fields[articles]=title,body&fields[comments]=tag
 article = Article.select("title", "body",{comments: 'tag'}).first
+
+# makes POST request to /articles?fields[articles]=title,body&fields[comments]=tag
+article = Article.new(title: 'New one').request_select(:title, :body, comments: 'tag')
+article.save
+
+# makes PATCH request to /articles/1?fields[articles]=title,body&fields[comments]=tag
+article = Article.find(1)
+article.title = 'Changed'
+article.request_select(:title, :body, comments: 'tag')
+article.save
+
+# request fields will be cleared if response is successful
+# to avoid this `keep_request_params` class attribute can be used
+Article.keep_request_params = true
+
+# to clear request fields use
+article.reset_request_select!(:comments) # to clear for comments
+article.reset_request_select! # to clear for all fields
 ```
 
 ## Sorting

--- a/lib/json_api_client.rb
+++ b/lib/json_api_client.rb
@@ -21,6 +21,7 @@ module JsonApiClient
   autoload :Paginating, 'json_api_client/paginating'
   autoload :Parsers, 'json_api_client/parsers'
   autoload :Query, 'json_api_client/query'
+  autoload :RequestParams, 'json_api_client/request_params'
   autoload :Resource, 'json_api_client/resource'
   autoload :ResultSet, 'json_api_client/result_set'
   autoload :Schema, 'json_api_client/schema'

--- a/lib/json_api_client/connection.rb
+++ b/lib/json_api_client/connection.rb
@@ -28,8 +28,10 @@ module JsonApiClient
       faraday.builder.delete(middleware)
     end
 
-    def run(request_method, path, params = {}, headers = {})
-      faraday.send(request_method, path, params, headers)
+    def run(request_method, path, params: nil, headers: {}, body: nil)
+      faraday.run_request(request_method, path, body, headers) do |request|
+        request.params.update(params) if params
+      end
     end
 
   end

--- a/lib/json_api_client/query/builder.rb
+++ b/lib/json_api_client/query/builder.rb
@@ -159,22 +159,7 @@ module JsonApiClient
       end
 
       def parse_related_links(*tables)
-        tables.map do |table|
-          case table
-          when Hash
-            table.map do |k, v|
-              parse_related_links(*v).map do |sub|
-                "#{k}.#{sub}"
-              end
-            end
-          when Array
-            table.map do |v|
-              parse_related_links(*v)
-            end
-          else
-            key_formatter.format(table)
-          end
-        end.flatten
+        Utils.parse_includes(klass, *tables)
       end
 
       def parse_orders(*args)

--- a/lib/json_api_client/request_params.rb
+++ b/lib/json_api_client/request_params.rb
@@ -1,0 +1,57 @@
+module JsonApiClient
+  class RequestParams
+    attr_reader :klass, :includes, :fields
+
+    def initialize(klass, includes: [], fields: {})
+      @klass = klass
+      @includes = includes
+      @fields = fields
+    end
+
+    def add_includes(includes)
+      Utils.parse_includes(klass, *includes).each do |name|
+        name = name.to_sym
+        self.includes.push(name) unless self.includes.include?(name)
+      end
+    end
+
+    def reset_includes!
+      @includes = []
+    end
+
+    def set_fields(type, field_names)
+      self.fields[type.to_sym] = field_names.map(&:to_sym)
+    end
+
+    def remove_fields(type)
+      self.fields.delete(type.to_sym)
+    end
+
+    def field_types
+      self.fields.keys
+    end
+
+    def clear
+      reset_includes!
+      @fields = {}
+    end
+
+    def to_params
+      return nil if field_types.empty? && includes.empty?
+      parsed_fields.merge(parsed_includes)
+    end
+
+    private
+
+    def parsed_includes
+      return {} if includes.empty?
+      {include: includes.join(",")}
+    end
+
+    def parsed_fields
+      return {} if field_types.empty?
+      {fields: fields.map { |type, names| [type, names.join(",")] }.to_h}
+    end
+
+  end
+end

--- a/lib/json_api_client/utils.rb
+++ b/lib/json_api_client/utils.rb
@@ -24,5 +24,24 @@ module JsonApiClient
       raise NameError, "uninitialized constant #{candidates.first}"
     end
 
+    def self.parse_includes(klass, *tables)
+      tables.map do |table|
+        case table
+        when Hash
+          table.map do |k, v|
+            parse_includes(klass, *v).map do |sub|
+              "#{k}.#{sub}"
+            end
+          end
+        when Array
+          table.map do |v|
+            parse_includes(klass, *v)
+          end
+        else
+          klass.key_formatter.format(table)
+        end
+      end.flatten
+    end
+
   end
 end


### PR DESCRIPTION
add ability to send includes and/or fields query params on resource create/update

TODO:
* [x]  code
* [x]  tests
* [x]  documentation

example
```ruby
article = Article.find(1).first
article.request_includes(:comments, author: :comments)
article.request_fields(articles: [:title], authors: [:name, :comments])
article.title = "changed title"
article.save
# PATCH /articles/1?fields[articles]=title&fields[authors]=name,comments&include=comments,author.comments
```