### PR TITLE
allow nil for page number parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,10 @@ articles = Article.page(2).per(30).to_a
 
 # also makes request to /articles?page=2&per_page=30
 articles = Article.paginate(page: 2, per_page: 30).to_a
+
+# keep in mind that page number can be nil - in that case default number will be applied
+# also makes request to /articles?page=1&per_page=30
+articles = Article.paginate(page: nil, per_page: 30).to_a
 ```
 
 *Note: The mapping of pagination parameters is done by the `query_builder` which is [customizable](#custom-paginator).*

--- a/lib/json_api_client/query/builder.rb
+++ b/lib/json_api_client/query/builder.rb
@@ -47,7 +47,7 @@ module JsonApiClient
       end
 
       def page(number)
-        @pagination_params[ klass.paginator.page_param ] = number
+        @pagination_params[ klass.paginator.page_param ] = number || 1
         self
       end
 


### PR DESCRIPTION
Consider `Model.page(nil)`
It is very happy if we can write `Model.page(params[:page])` like Kaminari.

* [x]  code changes
* [x]  readme update

rebased version of #189 