### PR TITLE
Use mocha/minitest instead of mocha/mini_test on test_helper

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,7 +3,7 @@ SimpleCov.start
 Bundler.require(:default, :test)
 require 'minitest/autorun'
 require 'webmock/minitest'
-require 'mocha/mini_test'
+require 'mocha/minitest'
 require 'pp'
 
 # shim for ActiveSupport 4.0.x requiring minitest 4.2


### PR DESCRIPTION
Fixes:  `require 'mocha/mini_test'` has been deprecated. Please use `require 'mocha/minitest' instead.`