### PR TITLE
Update arguments for custom connections run method in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ class NullConnection
   def initialize(*args)
   end
 
-  def run(request_method, path, params = {}, headers = {})
+  def run(request_method, path, params: nil, headers: {}, body: nil)
   end
 
   def use(*args); end


### PR DESCRIPTION
The method signature for `#run` on custom connection classes changed in https://github.com/JsonApiClient/json_api_client/commit/8dede9eca1cfa45f3e7354ae7e0c93dbbc8cb82e but the README hasn't been updated yet.

I had a heck of a time trying to debug this and track it down after upgrading!