### PR TITLE
define methods for properties and associations getter/setter

### DIFF
--- a/lib/json_api_client/associations/belongs_to.rb
+++ b/lib/json_api_client/associations/belongs_to.rb
@@ -1,15 +1,6 @@
 module JsonApiClient
   module Associations
     module BelongsTo
-      extend ActiveSupport::Concern
-
-      module ClassMethods
-        def belongs_to(attr_name, options = {})
-          # self.associations = self.associations + [HasOne::Association.new(attr_name, self, options)]
-          self.associations += [BelongsTo::Association.new(attr_name, self, options)]
-        end
-      end
-
       class Association < BaseAssociation
         include Helpers::URI
         def param

--- a/lib/json_api_client/associations/has_many.rb
+++ b/lib/json_api_client/associations/has_many.rb
@@ -1,14 +1,6 @@
 module JsonApiClient
   module Associations
     module HasMany
-      extend ActiveSupport::Concern
-
-      module ClassMethods
-        def has_many(attr_name, options = {})
-          self.associations = self.associations + [HasMany::Association.new(attr_name, self, options)]
-        end
-      end
-
       class Association < BaseAssociation
       end
     end

--- a/lib/json_api_client/associations/has_one.rb
+++ b/lib/json_api_client/associations/has_one.rb
@@ -1,14 +1,6 @@
 module JsonApiClient
   module Associations
     module HasOne
-      extend ActiveSupport::Concern
-
-      module ClassMethods
-        def has_one(attr_name, options = {})
-          self.associations += [HasOne::Association.new(attr_name, self, options)]
-        end
-      end
-
       class Association < BaseAssociation
         def from_result_set(result_set)
           result_set.first

--- a/lib/json_api_client/helpers.rb
+++ b/lib/json_api_client/helpers.rb
@@ -4,5 +4,6 @@ module JsonApiClient
     autoload :Dirty, 'json_api_client/helpers/dirty'
     autoload :DynamicAttributes, 'json_api_client/helpers/dynamic_attributes'
     autoload :URI, 'json_api_client/helpers/uri'
+    autoload :Associatable, 'json_api_client/helpers/associatable'
   end
 end

--- a/lib/json_api_client/helpers/associatable.rb
+++ b/lib/json_api_client/helpers/associatable.rb
@@ -1,0 +1,64 @@
+module JsonApiClient
+  module Helpers
+    module Associatable
+      extend ActiveSupport::Concern
+
+      included do
+        class_attribute :associations, instance_accessor: false
+        self.associations = []
+        attr_accessor :__cached_associations
+      end
+
+      module ClassMethods
+        def _define_association(attr_name, association_klass, options = {})
+          attr_name = attr_name.to_sym
+          association = association_klass.new(attr_name, self, options)
+          self.associations += [association]
+
+          define_method(attr_name) do
+            _cached_relationship(attr_name) do
+              relationship_definition = relationship_definition_for(attr_name)
+              return unless relationship_definition
+              relationship_data_for(attr_name, relationship_definition)
+            end
+          end
+
+          define_method("#{attr_name}=") do |value|
+            _clear_cached_relationship(attr_name)
+            relationships.public_send("#{attr_name}=", value)
+          end
+        end
+
+        def belongs_to(attr_name, options = {})
+          _define_association(attr_name, JsonApiClient::Associations::BelongsTo::Association, options)
+        end
+
+        def has_many(attr_name, options = {})
+          _define_association(attr_name, JsonApiClient::Associations::HasMany::Association, options)
+        end
+
+        def has_one(attr_name, options = {})
+          _define_association(attr_name, JsonApiClient::Associations::HasOne::Association, options)
+        end
+      end
+
+      def _cached_associations
+        self.__cached_associations ||= {}
+      end
+
+      def _clear_cached_relationships
+        self.__cached_associations = {}
+      end
+
+      def _clear_cached_relationship(attr_name)
+        _cached_associations.delete(attr_name)
+      end
+
+      def _cached_relationship(attr_name)
+        return _cached_associations[attr_name] if _cached_associations.has_key?(attr_name)
+        _cached_associations[attr_name] = yield
+      end
+
+    end
+  end
+end

--- a/lib/json_api_client/helpers/dynamic_attributes.rb
+++ b/lib/json_api_client/helpers/dynamic_attributes.rb
@@ -39,12 +39,7 @@ module JsonApiClient
 
       def method_missing(method, *args, &block)
         if has_attribute?(method)
-          self.class.class_eval do
-            define_method(method) do
-              attributes[method]
-            end
-          end
-          return send(method)
+          return attributes[method]
         end
 
         normalized_method = safe_key_formatter.unformat(method.to_s)

--- a/test/unit/resource_test.rb
+++ b/test/unit/resource_test.rb
@@ -86,8 +86,8 @@ class ResourceTest < MiniTest::Test
   def test_associations_as_params
     article = Article.new(foo: 'bar', 'author' => {'type' => 'authors', 'id' => 1})
     assert_equal(article.foo, 'bar')
-    assert_equal(article.attributes['author']['type'], 'authors')
-    assert_equal(article.attributes['author']['id'], 1)
+    assert_equal({'type' => 'authors', 'id' => 1}, article.relationships.author)
+    assert article.relationships.attribute_changed?(:author)
   end
 
   def test_default_params_overrideable

--- a/test/unit/updating_test.rb
+++ b/test/unit/updating_test.rb
@@ -212,6 +212,49 @@ class UpdatingTest < MiniTest::Test
     assert article.save
   end
 
+  def test_can_update_single_relationship_via_setter
+    articles = Article.find(1)
+    article = articles.first
+
+    stub_request(:patch, "http://example.com/articles/1")
+        .with(headers: {content_type: "application/vnd.api+json", accept: "application/vnd.api+json"}, body: {
+            data: {
+                id: "1",
+                type: "articles",
+                relationships: {
+                    author: {
+                        data: {
+                            type: "people",
+                            id: "1"
+                        }
+                    }
+                },
+                attributes: {}
+            }
+        }.to_json)
+        .to_return(headers: {status: 200, content_type: "application/vnd.api+json"}, body: {
+            data: {
+                type: "articles",
+                id: "1",
+                attributes: {
+                    title: "Rails is Omakase"
+                },
+                relationships: {
+                    author: {
+                        links: {
+                            self: "/articles/1/links/author",
+                            related: "/articles/1/author",
+                        },
+                        data: { type: "people", id: "1" }
+                    }
+                }
+            }
+        }.to_json)
+
+    article.author = Person.new(id: "1")
+    assert article.save
+  end
+
   def test_can_update_single_relationship_with_all_attributes_dirty
     articles = Article.find(1)
     article = articles.first
@@ -309,6 +352,55 @@ class UpdatingTest < MiniTest::Test
     article.relationships.comments = [
       Comment.new(id: "2"),
       Comment.new(id: "3")
+    ]
+    assert article.save
+  end
+
+  def test_can_update_has_many_relationships_via_setter
+    articles = Article.find(1)
+    article = articles.first
+
+    stub_request(:patch, "http://example.com/articles/1")
+        .with(headers: {content_type: "application/vnd.api+json", accept: "application/vnd.api+json"}, body: {
+            data: {
+                id: "1",
+                type: "articles",
+                relationships: {
+                    comments: {
+                        data: [{
+                                   type: "comments",
+                                   id: "2"
+                               },{
+                                   type: "comments",
+                                   id: "3"
+                               }]
+                    }
+                },
+                attributes: {}
+            }
+        }.to_json)
+        .to_return(headers: {status: 200, content_type: "application/vnd.api+json"}, body: {
+            data: {
+                id: "1",
+                type: "articles",
+                relationships: {
+                    author: {
+                        links: {
+                            self: "/articles/1/links/author",
+                            related: "/articles/1/author",
+                        },
+                        data: { type: "people", id: "1" }
+                    }
+                },
+                attributes: {
+                    title: "Rails is Omakase"
+                }
+            }
+        }.to_json)
+
+    article.comments = [
+        Comment.new(id: "2"),
+        Comment.new(id: "3")
     ]
     assert article.save
   end


### PR DESCRIPTION
## Description

* undo performance optimization introduced in #281 
* add performance optimization when defining properties and relationships
* introduce association setter

It's a bad practice to dynamically create methods when accessing method missing, so I changed a behavior of of static define attributes.

Generally I add accessors for each attribute that defined with `property` class method and relactionships that defined with `has_one`, `has_many`, and `belongs_to` class methods

performance may be decreased comparing to previous version unless you define `properties` for all accessed attributes