### PR TITLE
#299 optional get relationship from dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - [#316](https://github.com/JsonApiClient/json_api_client/pull/316) - Allow custom error messages
 
+- [#305](https://github.com/JsonApiClient/json_api_client/pull/305) - optional search relationship data in result set
+
 ## 1.7.0
 
 - [#320](https://github.com/JsonApiClient/json_api_client/pull/320) - fix passing relationships on create

--- a/lib/json_api_client/resource.rb
+++ b/lib/json_api_client/resource.rb
@@ -34,6 +34,7 @@ module JsonApiClient
                     :route_format,
                     :request_params_class,
                     :keep_request_params,
+                    :search_included_in_result_set,
                     instance_accessor: false
     class_attribute :add_defaults_to_changes,
                     instance_writer: false
@@ -50,6 +51,7 @@ module JsonApiClient
     self.request_params_class = RequestParams
     self.keep_request_params = false
     self.add_defaults_to_changes = false
+    self.search_included_in_result_set = false
 
     #:underscored_key, :camelized_key, :dasherized_key, or custom
     self.json_key_format = :underscored_key


### PR DESCRIPTION
related to #299 

simple example

```ruby
class Employee < JsonApiClient::Resource
  self.search_included_in_result_set = true
  has_one :chief, klass: 'Employee'
end

stub_request(:get, '/employees?include=chief') do
{ data: [
    {
        id: '1', 
        type: 'employees', 
        attributes: {  name: 'John' },
        relationships: {
            chief: {
                data: null
            }
        }
    },
    {
        id: '2', 
        type: 'employees', 
        attributes: {  name: 'Bob' },
        relationships: {
            chief: {
                data: { id: '1', type: 'employees' }
            }
        }
    }
] }.to_json
end
employees = Employee.includes(:chief) # responds with
bob = employees.detect { |e| e.name == 'Bob' }
assert_equal 'John', bob.chief.name
```