### PR TITLE
#290 symbolize params keys on model initialize

### DIFF
--- a/lib/json_api_client/resource.rb
+++ b/lib/json_api_client/resource.rb
@@ -309,9 +309,10 @@ module JsonApiClient
     #
     # @param params [Hash] Attributes, links, and relationships
     def initialize(params = {})
+      params = params.symbolize_keys
       @persisted = nil
-      self.links = self.class.linker.new(params.delete("links") || {})
-      self.relationships = self.class.relationship_linker.new(self.class, params.delete("relationships") || {})
+      self.links = self.class.linker.new(params.delete(:links) || {})
+      self.relationships = self.class.relationship_linker.new(self.class, params.delete(:relationships) || {})
       self.attributes = self.class.default_attributes.merge(params)
 
       self.class.schema.each_property do |property|

--- a/test/unit/creation_test.rb
+++ b/test/unit/creation_test.rb
@@ -271,4 +271,41 @@ class CreationTest < MiniTest::Test
     assert_equal 100, callback_test.bar
   end
 
+  def test_create_with_relationships_in_payload
+    stub_request(:post, 'http://example.com/articles')
+        .with(headers: {content_type: 'application/vnd.api+json', accept: 'application/vnd.api+json'}, body: {
+            data: {
+                type: 'articles',
+                attributes: {
+                    title: 'Rails is Omakase'
+                },
+                relationships: {
+                    comments: {
+                        data: [
+                            {
+                                id: '2',
+                                type: 'comments'
+                            }
+                        ]
+                    }
+                }
+            }
+        }.to_json)
+        .to_return(headers: {content_type: 'application/vnd.api+json'}, body: {
+            data: {
+                type: 'articles',
+                id: '1',
+                attributes: {
+                    title: 'Rails is Omakase'
+                }
+            }
+        }.to_json)
+
+    article = Article.new(title: 'Rails is Omakase', relationships: {comments: [Comment.new(id: 2)]})
+
+    assert article.save
+    assert article.persisted?
+    assert_equal "1", article.id
+  end
+
 end


### PR DESCRIPTION
it will fix behavior when relationships and links are passed as symbol keys

related to #290