### PR TITLE
Do not raise errors on 422 responses

### DIFF
--- a/lib/json_api_client/middleware/status.rb
+++ b/lib/json_api_client/middleware/status.rb
@@ -28,6 +28,8 @@ module JsonApiClient
           raise Errors::NotFound, env[:url]
         when 409
           raise Errors::Conflict, env
+        when 422
+          # Allow to proceed as resource errors will be populated
         when 400..499
           raise Errors::ClientError, env
         when 500..599

--- a/test/unit/status_test.rb
+++ b/test/unit/status_test.rb
@@ -69,4 +69,16 @@ class StatusTest < MiniTest::Test
       User.find(1)
     end
   end
+
+  def test_server_responding_with_422_status
+    stub_request(:get, "http://example.com/users/1")
+      .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
+        meta: {
+          status: 422
+        }
+      }.to_json)
+
+    # We want to test that this response does not raise an error
+    User.find(1)
+  end
 end


### PR DESCRIPTION
Discussed here https://github.com/JsonApiClient/json_api_client/pull/311#issuecomment-428965558

JSON APIs often return validation errors with 422 so the client would be
notified that the response was not successful by the existence of the
resource errors.