### PR TITLE
add shallow path for belongs_to

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,13 +157,17 @@ articles.links.related
 
 You can force nested resource paths for your models by using a `belongs_to` association.
 
-**Note: Using belongs_to is only necessary for setting a nested path.**
+**Note: Using belongs_to is only necessary for setting a nested path unless you provide `shallow_path: true` option.**
 
 ```ruby
 module MyApi
   class Account < JsonApiClient::Resource
     belongs_to :user
   end
+  
+  class Customer < JsonApiClient::Resource
+      belongs_to :user, shallow_path: true
+    end
 end
 
 # try to find without the nested parameter
@@ -172,6 +176,28 @@ MyApi::Account.find(1)
 
 # makes request to /users/2/accounts/1
 MyApi::Account.where(user_id: 2).find(1)
+# => returns ResultSet
+
+# makes request to /customers/1
+MyApi::Customer.find(1)
+# => returns ResultSet
+
+# makes request to /users/2/customers/1
+MyApi::Customer.where(user_id: 2).find(1)
+# => returns ResultSet
+```
+
+you can also override param name for `belongs_to` association
+
+```ruby
+module MyApi
+  class Account < JsonApiClient::Resource
+    belongs_to :user, param: :customer_id
+  end
+end
+
+# makes request to /users/2/accounts/1
+MyApi::Account.where(customer_id: 2).find(1)
 # => returns ResultSet
 ```
 

--- a/lib/json_api_client/associations/belongs_to.rb
+++ b/lib/json_api_client/associations/belongs_to.rb
@@ -3,8 +3,17 @@ module JsonApiClient
     module BelongsTo
       class Association < BaseAssociation
         include Helpers::URI
-        def param
-          :"#{attr_name}_id"
+
+        attr_reader :param
+
+        def initialize(attr_name, klass, options = {})
+          super
+          @param = options.fetch(:param, :"#{attr_name}_id").to_sym
+          @shallow_path = options.fetch(:shallow_path, false)
+        end
+
+        def shallow_path?
+          @shallow_path
         end
 
         def to_prefix_path(formatter)
@@ -12,6 +21,7 @@ module JsonApiClient
         end
 
         def set_prefix_path(attrs, formatter)
+          return if shallow_path? && !attrs[param]
           attrs[param] = encode_part(attrs[param]) if attrs.key?(param)
           to_prefix_path(formatter) % attrs
         end

--- a/lib/json_api_client/helpers/associatable.rb
+++ b/lib/json_api_client/helpers/associatable.rb
@@ -7,6 +7,7 @@ module JsonApiClient
         class_attribute :associations, instance_accessor: false
         self.associations = []
         attr_accessor :__cached_associations
+        attr_accessor :__belongs_to_params
       end
 
       module ClassMethods
@@ -14,6 +15,10 @@ module JsonApiClient
           attr_name = attr_name.to_sym
           association = association_klass.new(attr_name, self, options)
           self.associations += [association]
+        end
+
+        def _define_relationship_methods(attr_name)
+          attr_name = attr_name.to_sym
 
           define_method(attr_name) do
             _cached_relationship(attr_name) do
@@ -31,15 +36,34 @@ module JsonApiClient
 
         def belongs_to(attr_name, options = {})
           _define_association(attr_name, JsonApiClient::Associations::BelongsTo::Association, options)
+
+          param = associations.last.param
+          define_method(param) do
+            _belongs_to_params[param]
+          end
+
+          define_method(:"#{param}=") do |value|
+            _belongs_to_params[param] = value
+          end
         end
 
         def has_many(attr_name, options = {})
           _define_association(attr_name, JsonApiClient::Associations::HasMany::Association, options)
+          _define_relationship_methods(attr_name)
         end
 
         def has_one(attr_name, options = {})
           _define_association(attr_name, JsonApiClient::Associations::HasOne::Association, options)
+          _define_relationship_methods(attr_name)
         end
+      end
+
+      def _belongs_to_params
+        self.__belongs_to_params ||= {}
+      end
+
+      def _clear_belongs_to_params
+        self.__belongs_to_params = {}
       end
 
       def _cached_associations

--- a/lib/json_api_client/query/builder.rb
+++ b/lib/json_api_client/query/builder.rb
@@ -1,3 +1,5 @@
+require 'active_support/all'
+
 module JsonApiClient
   module Query
     class Builder
@@ -64,8 +66,12 @@ module JsonApiClient
         paginate(page: 1, per_page: 1).pages.last.to_a.last
       end
 
-      def build
-        klass.new(params)
+      def build(attrs = {})
+        klass.new @path_params.merge(attrs.symbolize_keys)
+      end
+
+      def create(attrs = {})
+        klass.create @path_params.merge(attrs.symbolize_keys)
       end
 
       def params

--- a/lib/json_api_client/query/requestor.rb
+++ b/lib/json_api_client/query/requestor.rb
@@ -10,14 +10,14 @@ module JsonApiClient
 
       # expects a record
       def create(record)
-        request(:post, klass.path(record.attributes), {
+        request(:post, klass.path(record.path_attributes), {
             body: { data: record.as_json_api },
             params: record.request_params.to_params
         })
       end
 
       def update(record)
-        request(:patch, resource_path(record.attributes), {
+        request(:patch, resource_path(record.path_attributes), {
             body: { data: record.as_json_api },
             params: record.request_params.to_params
         })
@@ -30,7 +30,7 @@ module JsonApiClient
       end
 
       def destroy(record)
-        request(:delete, resource_path(record.attributes))
+        request(:delete, resource_path(record.path_attributes))
       end
 
       def linked(path)


### PR DESCRIPTION
fix #180 

usage: 
```ruby
class BaseResource < JsonApiClient::Resource
  self.site = "http://example.com/api"
end

class Parent < BaseResource
  has_many :children, class_name: 'Child'
end

class Child < BaseResource
  belongs_to :parent, shallow_path: true
  has_one :parent
end

parent = Parent.find(1)
Child.create(name: 'foo', parent: parent) # POST /api/children with parent relationship in payload
Child.create(name: 'bar', parent_id: parent.id) POST /api/parents/1/children
```