### PR TITLE
Allow custom error messages

### DIFF
--- a/lib/json_api_client/resource.rb
+++ b/lib/json_api_client/resource.rb
@@ -568,10 +568,14 @@ module JsonApiClient
       relationships.as_json_api
     end
 
+    def error_message_for(error)
+      error.error_msg
+    end
+
     def fill_errors
       last_result_set.errors.each do |error|
         key = self.class.key_formatter.unformat(error.error_key)
-        errors.add(key, error.error_msg)
+        errors.add(key, error_message_for(error))
       end
     end
   end


### PR DESCRIPTION
* Adds ability to override key in resource to surface different error messages

Simply override `error_msg_key` in your resource and you can set what value to use for your error