### PR TITLE
Creation with relation fail

### DIFF
--- a/test/unit/creation_test.rb
+++ b/test/unit/creation_test.rb
@@ -272,42 +272,4 @@ class CreationTest < MiniTest::Test
     callback_test = CallbackTest.create({foo: 1, bar: 1})
     assert_equal 100, callback_test.bar
   end
-
-  def test_create_with_relationships_in_payload
-    stub_request(:post, 'http://example.com/articles')
-        .with(headers: {content_type: 'application/vnd.api+json', accept: 'application/vnd.api+json'}, body: {
-            data: {
-                type: 'articles',
-                attributes: {
-                    title: 'Rails is Omakase'
-                },
-                relationships: {
-                    comments: {
-                        data: [
-                            {
-                                id: '2',
-                                type: 'comments'
-                            }
-                        ]
-                    }
-                }
-            }
-        }.to_json)
-        .to_return(headers: {content_type: 'application/vnd.api+json'}, body: {
-            data: {
-                type: 'articles',
-                id: '1',
-                attributes: {
-                    title: 'Rails is Omakase'
-                }
-            }
-        }.to_json)
-
-    article = Article.new(title: 'Rails is Omakase', relationships: {comments: [Comment.new(id: 2)]})
-
-    assert article.save
-    assert article.persisted?
-    assert_equal "1", article.id
-  end
-
 end

--- a/test/unit/creation_with_relation_test.rb
+++ b/test/unit/creation_with_relation_test.rb
@@ -1,0 +1,40 @@
+require 'test_helper'
+
+class CreationWithRelationTest < MiniTest::Test
+  def test_create_with_relationships_in_payload
+    stub_request(:post, 'http://example.com/articles')
+        .with(headers: {content_type: 'application/vnd.api+json', accept: 'application/vnd.api+json'}, body: {
+            data: {
+                type: 'articles',
+                attributes: {
+                    title: 'Rails is Omakase'
+                },
+                relationships: {
+                    comments: {
+                        data: [
+                            {
+                                id: '2',
+                                type: 'comments'
+                            }
+                        ]
+                    }
+                }
+            }
+        }.to_json)
+        .to_return(headers: {content_type: 'application/vnd.api+json'}, body: {
+            data: {
+                type: 'articles',
+                id: '1',
+                attributes: {
+                    title: 'Rails is Omakase'
+                }
+            }
+        }.to_json)
+
+    article = Article.new(title: 'Rails is Omakase', relationships: {comments: [Comment.new(id: 2)]})
+
+    assert article.save
+    assert article.persisted?
+    assert_equal "1", article.id
+  end
+end


### PR DESCRIPTION
This shows that the `test_create_with_relationships_in_payload` test fails when outside the `creation_test.rb` because the stub request pattern matching triggers on the setup block, never actually using the stub in the test.