### PR TITLE
Retain context from Faraday errors

### DIFF
--- a/lib/json_api_client/errors.rb
+++ b/lib/json_api_client/errors.rb
@@ -2,7 +2,8 @@ module JsonApiClient
   module Errors
     class ApiError < StandardError
       attr_reader :env
-      def initialize(env)
+      def initialize(env, msg = nil)
+        super msg
         @env = env
       end
     end
@@ -20,14 +21,14 @@ module JsonApiClient
     end
 
     class ServerError < ApiError
-      def message
-        "Internal server error"
+      def initialize(env, msg = 'Internal server error')
+        super env, msg
       end
     end
 
     class Conflict < ServerError
-      def message
-        "Resource already exists"
+      def initialize(env, msg = 'Resource already exists')
+        super env, msg
       end
     end
 
@@ -51,6 +52,5 @@ module JsonApiClient
         "Unexpected response status: #{code} from: #{uri.to_s}"
       end
     end
-
   end
 end

--- a/lib/json_api_client/middleware/status.rb
+++ b/lib/json_api_client/middleware/status.rb
@@ -11,8 +11,8 @@ module JsonApiClient
             handle_status(code, env)
           end
         end
-      rescue Faraday::ConnectionFailed, Faraday::TimeoutError
-        raise Errors::ConnectionError, environment
+      rescue Faraday::ConnectionFailed, Faraday::TimeoutError => e
+        raise Errors::ConnectionError.new environment, e.to_s
       end
 
       protected

--- a/test/unit/errors_test.rb
+++ b/test/unit/errors_test.rb
@@ -4,11 +4,13 @@ class ErrorsTest < MiniTest::Test
 
   def test_connection_errors
     stub_request(:get, "http://example.com/users")
-      .to_raise(Faraday::ConnectionFailed)
+      .to_raise(Faraday::ConnectionFailed.new("specific message"))
 
-    assert_raises JsonApiClient::Errors::ConnectionError do
+    err = assert_raises JsonApiClient::Errors::ConnectionError do
       User.all
     end
+
+    assert_match /specific message/, err.message
   end
 
   def test_timeout_errors


### PR DESCRIPTION
This PR fixes #192: when a `JsonApiClient::Errors::ConnectionError` is raised, the original message from the underlying error (`Faraday::ConnectionFailed` or `Faraday::TimeoutError`) is included.