### PR TITLE
allow custom type for models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 - [#305](https://github.com/JsonApiClient/json_api_client/pull/305) - optional search relationship data in result set
 
+- [#328](https://github.com/JsonApiClient/json_api_client/pull/328) - allow custom type for models
+
 ## 1.7.0
 
 - [#320](https://github.com/JsonApiClient/json_api_client/pull/320) - fix passing relationships on create

--- a/README.md
+++ b/README.md
@@ -553,6 +553,22 @@ class MyApi::Base < JsonApiClient::Resource
 end
 ```
 
+### Custom type
+
+If your model must be named differently from classified type of resource you can easily customize it.
+It will work both for defined and not defined relationships
+
+```ruby
+class MyApi::Base < JsonApiClient::Resource
+  resolve_custom_type 'document--files', 'File'
+end
+
+class MyApi::File < MyApi::Base
+  def self.resource_name
+    'document--files'
+  end
+end
+```
 
 ### Type Casting
 

--- a/lib/json_api_client/resource.rb
+++ b/lib/json_api_client/resource.rb
@@ -35,6 +35,7 @@ module JsonApiClient
                     :request_params_class,
                     :keep_request_params,
                     :search_included_in_result_set,
+                    :custom_type_to_class,
                     instance_accessor: false
     class_attribute :add_defaults_to_changes,
                     instance_writer: false
@@ -52,6 +53,7 @@ module JsonApiClient
     self.keep_request_params = false
     self.add_defaults_to_changes = false
     self.search_included_in_result_set = false
+    self.custom_type_to_class = {}
 
     #:underscored_key, :camelized_key, :dasherized_key, or custom
     self.json_key_format = :underscored_key
@@ -62,6 +64,11 @@ module JsonApiClient
     class << self
       extend Forwardable
       def_delegators :_new_scope, :where, :order, :includes, :select, :all, :paginate, :page, :with_params, :first, :find, :last
+
+      def resolve_custom_type(type_name, class_name)
+        classified_type = key_formatter.unformat(type_name.to_s).singularize.classify
+        self.custom_type_to_class = custom_type_to_class.merge(classified_type => class_name.to_s)
+      end
 
       # The table name for this resource. i.e. Article -> articles, Person -> people
       #

--- a/lib/json_api_client/utils.rb
+++ b/lib/json_api_client/utils.rb
@@ -2,6 +2,7 @@ module JsonApiClient
   module Utils
 
     def self.compute_type(klass, type_name)
+      return klass.custom_type_to_class.fetch(type_name).constantize if klass.custom_type_to_class.key?(type_name)
       # If the type is prefixed with a scope operator then we assume that
       # the type_name is an absolute reference.
       return type_name.constantize if type_name.match(/^::/)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,6 +35,21 @@ class UserPreference < TestResource
   self.primary_key = :user_id
 end
 
+class DocumentUser < TestResource
+  resolve_custom_type 'document--files', 'DocumentFile'
+end
+
+class DocumentStore < TestResource
+  resolve_custom_type 'document--files', 'DocumentFile'
+  has_many :files, class_name: 'DocumentFile'
+end
+
+class DocumentFile < TestResource
+  def self.resource_name
+    'document--files'
+  end
+end
+
 def with_altered_config(resource_class, changes)
   # remember and overwrite config
   old_config_values = {}

--- a/test/unit/creation_test.rb
+++ b/test/unit/creation_test.rb
@@ -314,4 +314,31 @@ class CreationTest < MiniTest::Test
     assert_equal "1", article.id
   end
 
+  def test_create_with_custom_type
+    stub_request(:post, 'http://example.com/document--files')
+        .with(headers: {content_type: 'application/vnd.api+json', accept: 'application/vnd.api+json'}, body: {
+            data: {
+                type: 'document--files',
+                attributes: {
+                    url: 'http://example.com/downloads/1.pdf'
+                }
+            }
+        }.to_json)
+        .to_return(headers: {content_type: 'application/vnd.api+json'}, body: {
+            data: {
+                type: 'document--files',
+                id: '1',
+                attributes: {
+                    url: 'http://example.com/downloads/1.pdf'
+                }
+            }
+        }.to_json)
+
+    file = DocumentFile.new(url: 'http://example.com/downloads/1.pdf')
+
+    assert file.save
+    assert file.persisted?
+    assert_equal '1', file.id
+  end
+
 end

--- a/test/unit/finding_test.rb
+++ b/test/unit/finding_test.rb
@@ -77,4 +77,26 @@ class FindingTest < MiniTest::Test
     assert_equal ["2", "3"], articles.map(&:id)
   end
 
+  def test_find_by_id_with_custom_type
+    stub_request(:get, "http://example.com/document--files/1")
+        .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
+            data: {
+                type: "document--files",
+                id: "1",
+                attributes: {
+                    url: 'http://example.com/downloads/1.pdf'
+                }
+            }
+        }.to_json)
+
+    articles = DocumentFile.find(1)
+
+    assert articles.is_a?(JsonApiClient::ResultSet)
+    assert_equal 1, articles.length
+
+    article = articles.first
+    assert_equal '1', article.id
+    assert_equal 'http://example.com/downloads/1.pdf', article.url
+  end
+
 end


### PR DESCRIPTION
fixes #288

example
```ruby
class MyApi::Base < JsonApiClient::Resource
  resolve_custom_type 'document--files', 'File'
end
 class MyApi::File < MyApi::Base
  def self.resource_name
    'document--files'
  end
end
```