### PR TITLE
Deletion for primary keys

### DIFF
--- a/lib/json_api_client/resource.rb
+++ b/lib/json_api_client/resource.rb
@@ -394,7 +394,7 @@ module JsonApiClient
     #
     # @return [Hash] Representation of this object as JSONAPI object
     def as_json_api(*)
-      attributes.slice(:id, :type).tap do |h|
+      attributes.slice(self.class.primary_key, :type).tap do |h|
         relationships_for_serialization.tap do |r|
           h[:relationships] = self.class.key_formatter.format_keys(r) unless r.empty?
         end
@@ -403,11 +403,11 @@ module JsonApiClient
     end
 
     def as_json(*)
-      attributes.slice(:id, :type).tap do |h|
+      attributes.slice(self.class.primary_key, :type).tap do |h|
         relationships.as_json.tap do |r|
           h[:relationships] = r unless r.empty?
         end
-        h[:attributes] = attributes.except(:id, :type).as_json
+        h[:attributes] = attributes.except(self.class.primary_key, :type).as_json
       end
     end
 
@@ -504,7 +504,7 @@ module JsonApiClient
     end
 
     def path_attributes
-      _belongs_to_params.merge attributes.slice('id').symbolize_keys
+      _belongs_to_params.merge attributes.slice( self.class.primary_key ).symbolize_keys
     end
 
     protected

--- a/test/unit/destroying_test.rb
+++ b/test/unit/destroying_test.rb
@@ -36,6 +36,33 @@ class DestroyingTest < MiniTest::Test
     assert_equal(1, user.id)
   end
 
+  def test_destroy_custom_primary_key
+    stub_request(:get, "http://example.com/user_preferences/105")
+      .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
+        data: [
+          {attributes: { user_id: 105, name: "Jeff Ching", email_address: "ching.jeff@gmail.com"}}
+        ]
+      }.to_json)
+
+    $print_load = true
+    user_prefrence = UserPreference.find(105).first
+    assert(user_prefrence.persisted?)
+    $print_load = false
+    assert_equal(false, user_prefrence.new_record?)
+    assert_equal(false, user_prefrence.destroyed?)
+
+    stub_request(:delete, "http://example.com/user_preferences/105")
+      .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
+        data: []
+      }.to_json)
+
+    assert(user_prefrence.destroy, "successful deletion should return truish value")
+    assert_equal(false, user_prefrence.persisted?)
+    assert_equal(false, user_prefrence.new_record?)
+    assert(user_prefrence.destroyed?)
+    assert_equal(105, user_prefrence.user_id)
+  end
+
   def test_destroy_no_content
     stub_request(:delete, "http://example.com/users/6")
       .to_return(headers: {content_type: "application/vnd.api+json"}, body: nil)


### PR DESCRIPTION
Adding deletion support for resources whose `primary_key` is not `id`. 
Now if you have a resource that looks like

```ruby
module MyAPI
  class User < Base
    self.primary_key = :guid
  end
end
```

the `DELETE` request will use the `guid` from `attributes` rather than doing a `DELETE my.api/users/`