### PR TITLE
Implement eql and hash for Builder class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [#338](https://github.com/JsonApiClient/json_api_client/pull/338) - implement hash and eql? for builder class
+
 ## 1.13.0
 
 - [#348](https://github.com/JsonApiClient/json_api_client/pull/348) - add NestedParamPaginator to address inconsistency in handling of pagination query string params (issue [#347](https://github.com/JsonApiClient/json_api_client/issues/347)).

--- a/lib/json_api_client/query/builder.rb
+++ b/lib/json_api_client/query/builder.rb
@@ -109,6 +109,20 @@ module JsonApiClient
         to_a.send(method_name, *args, &block)
       end
 
+      def hash
+        [
+          klass,
+          params
+        ].hash
+      end
+
+      def ==(other)
+        return false unless other.is_a?(self.class)
+
+        hash == other.hash
+      end
+      alias_method :eql?, :==
+
       protected
 
       def _fetch

--- a/test/unit/query_builder_test.rb
+++ b/test/unit/query_builder_test.rb
@@ -312,4 +312,24 @@ class QueryBuilderTest < MiniTest::Test
     assert_equal '123', record.author_id
     assert_equal [], record.relationships.changed
   end
+
+  def test_build_hash_sum
+    a = ArticleNested.where(author_id: '123', name: 'John')
+    b = ArticleNested.where(author_id: '123', name: 'John')
+    c = ArticleNested.where(author_id: '123')
+    d = Article.where(author_id: '123', name: 'John')
+    assert(a.hash == b.hash)
+    assert_equal(false, a.hash == c.hash)
+    assert_equal(false, a.hash == d.hash)
+  end
+
+  def test_build_eql
+    a = ArticleNested.where(author_id: '123', name: 'John')
+    b = ArticleNested.where(author_id: '123', name: 'John')
+    c = ArticleNested.where(author_id: '123')
+    d = Article.where(author_id: '123', name: 'John')
+    assert(a == b)
+    assert_equal(false, a == c)
+    assert_equal(false, a == d)
+  end
 end


### PR DESCRIPTION
I think it would make sense to implement `hash` and `eql?` on the builder.

One usecase we have is to cache a response for a couple of minutes and therefore we needed to implement hash.