### PR TITLE
Fallback to fetching the association if relationship data was not found in included

### DIFF
--- a/lib/json_api_client/included_data.rb
+++ b/lib/json_api_client/included_data.rb
@@ -43,7 +43,8 @@ module JsonApiClient
 
     # should return a resource record of some type for this linked document
     def record_for(link_def)
-      data.dig(link_def["type"], link_def["id"])
+      type_data = data[link_def["type"]]
+      type_data && type_data[link_def["id"]]
     end
   end
 end

--- a/lib/json_api_client/included_data.rb
+++ b/lib/json_api_client/included_data.rb
@@ -43,7 +43,7 @@ module JsonApiClient
 
     # should return a resource record of some type for this linked document
     def record_for(link_def)
-      data[link_def["type"]][link_def["id"]]
+      data.dig(link_def["type"], link_def["id"])
     end
   end
 end

--- a/lib/json_api_client/resource.rb
+++ b/lib/json_api_client/resource.rb
@@ -539,16 +539,18 @@ module JsonApiClient
       if relationship_definition.key?("data")
         if relationships.attribute_changed?(name)
           return relation_objects_for(name, relationship_definition)
+        elsif relationship_definition["data"].nil?
+          # data is explicitly nil, respect that
+          return
         else
           data = included_data_for(name, relationship_definition)
           return data if data
         end
       end
 
-      url = relationship_definition["links"]["related"]
-      if relationship_definition["links"] && url
-        return association_for(name).data(url)
-      end
+      links = relationship_definition["links"]
+      url = links && links["related"]
+      return association_for(name).data(url) if url
 
       nil
     end

--- a/lib/json_api_client/resource.rb
+++ b/lib/json_api_client/resource.rb
@@ -540,7 +540,8 @@ module JsonApiClient
         if relationships.attribute_changed?(name)
           return relation_objects_for(name, relationship_definition)
         else
-          return included_data_for(name, relationship_definition)
+          data = included_data_for(name, relationship_definition)
+          return data if data
         end
       end
 

--- a/test/unit/association_test.rb
+++ b/test/unit/association_test.rb
@@ -296,6 +296,50 @@ class AssociationTest < MiniTest::Test
     assert_equal Owner, owner.class
   end
 
+  def test_has_one_with_data_without_included_fetches_relationship
+    stub_request(:get, "http://example.com/properties/1")
+      .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
+        data: [
+          {
+            id: 1,
+            type: "addresses",
+            attributes: {
+              address: "123 Main St."
+            },
+            relationships: {
+              owner: {
+                links: {
+                  self: 'http://example.com/properties/1/links/owner',
+                  related: 'http://example.com/owners/1'
+                },
+                data: {
+                  type: "owners",
+                  id: 1
+                }
+              }
+            }
+          }
+        ]
+      }.to_json)
+    stub_request(:get, "http://example.com/owners/1")
+      .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
+        data: [
+          {
+            id: 1,
+            type: "owner",
+            attributes: {
+              name: "Jeff Ching"
+            }
+          }
+        ]
+      }.to_json)
+
+    property = Property.find(1).first
+    owner = property.owner
+    assert owner, "expected to be able to fetch relationship if defined and contains basic data but not included"
+    assert_equal Owner, owner.class
+  end
+
   def test_has_many_fetches_relationship
     stub_request(:get, "http://example.com/owners/1")
       .to_return(headers: {content_type: "application/vnd.api+json"}, body: {


### PR DESCRIPTION
Given a payload that looks something like

```
{
  "data": {
    ...
    "relationships": {
      "owner": {
        "links": { ... },
        "data": { "type": "owners", "id": 1 }
      }
    }
  }
}
```

where the relationship has `data`, but whose full data does not appear in `included`, the current code will raise an exception `undefined method '[]' for nil:NilClass`.

This PR changes how the included data is accessed that avoids this exception, by using `Hash#dig`. It then falls back to fetching the relationship via a request.