### PR TITLE
Add `raise_on_blank_find_param` resource setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [#344](https://github.com/JsonApiClient/json_api_client/pull/344) - introduce safe singular resource fetching with `raise_on_blank_find_param` resource setting
+
 ## 1.9.0
 
 - [#328](https://github.com/JsonApiClient/json_api_client/pull/328) - allow custom type for models
@@ -27,7 +29,7 @@
   * fix relationships passing to `new` and `create` methods
   * fix false positive tests on create
   * refactor tests on create/update to prevent false same positive tests in future
-  
+
 - [#315](https://github.com/JsonApiClient/json_api_client/pull/315) - add shallow_path feature to belongs_to
  * add `shallow_path` options to belongs_to to use model w/ and w/o nesting in parent resource
 

--- a/lib/json_api_client/resource.rb
+++ b/lib/json_api_client/resource.rb
@@ -36,6 +36,7 @@ module JsonApiClient
                     :keep_request_params,
                     :search_included_in_result_set,
                     :custom_type_to_class,
+                    :raise_on_blank_find_param,
                     instance_accessor: false
     class_attribute :add_defaults_to_changes,
                     instance_writer: false
@@ -54,6 +55,7 @@ module JsonApiClient
     self.add_defaults_to_changes = false
     self.search_included_in_result_set = false
     self.custom_type_to_class = {}
+    self.raise_on_blank_find_param = false
 
     #:underscored_key, :camelized_key, :dasherized_key, or custom
     self.json_key_format = :underscored_key


### PR DESCRIPTION
The problem comes from https://github.com/JsonApiClient/json_api_client/issues/329

That is a bit curios, but `json_api_client` returns an array from `.find` method, always.
The history of this fact was discussed [here](https://github.com/JsonApiClient/json_api_client/issues/75)

So, when we searching for a single resource by primary key, we typically write the things like

```ruby
admin = User.find(id).first
```

The next thing which we need to notice - `json_api_client` will just interpolate the incoming `.find` param to the end of API URL, just like that:

> http://somehost/api/v1/users/{id}

What will happen if we pass the blank id (nil or empty string) to the `.find` method then?.. Yeah, `json_api_client` will try to call the INDEX API endpoint instead of SHOW one:

> http://somehost/api/v1/users/

Lets sum all together - in case if `id` comes blank (from CGI for instance), we can silently receive the `admin` variable equal to some existing resource, with all the consequences.

Even worse, `admin` variable can equal to *random* resource, depends on ordering applied by INDEX endpoint.

If you prefer to get `JsonApiClient::Errors::NotFound` raised, please define in your base Resource class:

```ruby
class Resource < JsonApiClient::Resource
  self.raise_on_blank_find_param = true
end
```