### PR TITLE
Add an immutable option to JSON API resources.

### DIFF
--- a/lib/json_api_client/errors.rb
+++ b/lib/json_api_client/errors.rb
@@ -11,6 +11,12 @@ module JsonApiClient
     class ClientError < ApiError
     end
 
+    class ResourceImmutableError < StandardError
+      def initialize(msg = 'Resource immutable')
+        super msg
+      end
+    end
+
     class AccessDenied < ClientError
     end
 

--- a/test/unit/resource_test.rb
+++ b/test/unit/resource_test.rb
@@ -95,4 +95,14 @@ class ResourceTest < MiniTest::Test
     assert_equal(article.type, 'Story')
   end
 
+  def test_immutable
+    Article.immutable(true)
+    article = Article.new(type: 'Story')
+    assert_raises JsonApiClient::Errors::ResourceImmutableError do
+      article.save
+    end
+  ensure
+    Article.immutable(false)
+  end
+
 end


### PR DESCRIPTION
JSON API has an `immutable` trait that can be applied on a resource level - I thought it would be useful to recreate that functionality here.

Most of the work was done by @senid231.

Discussed here:
https://github.com/JsonApiClient/json_api_client/issues/343