### PR TITLE
Fix resource including for STI objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [#349](https://github.com/JsonApiClient/json_api_client/pull/349) - fix resource including for STI objects
+
 ## 1.12.0
 
 - [#345](https://github.com/JsonApiClient/json_api_client/pull/345) - track the real HTTP reason of ApiErrors

--- a/test/unit/association_test.rb
+++ b/test/unit/association_test.rb
@@ -854,6 +854,48 @@ class AssociationTest < MiniTest::Test
     assert user.files.first.is_a?(DocumentFile)
   end
 
+  def test_get_with_type_attribute
+    stub_request(:get, "http://example.com/document_users/1?include=file")
+        .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
+            data: [
+                {
+                    id: '1',
+                    type: 'document_users',
+                    attributes: {
+                        name: 'John Doe'
+                    },
+                    relationships: {
+                        file: {
+                            links: {
+                                self: 'http://example.com/document_users/1/relationships/file',
+                                related: 'http://example.com/document_users/1/file'
+                            },
+                            data: {
+                                id: '2',
+                                type: 'document--files'
+                            }
+                        }
+                    }
+                }
+            ],
+            included: [
+                {
+                    id: '2',
+                    type: 'document--files',
+                    attributes: {
+                        type: 'STIDocumentFile',
+                        url: 'http://example.com/downloads/2.pdf'
+                    }
+                }
+            ]
+        }.to_json)
+
+    user = DocumentUser.includes('file').find(1).first
+
+    assert_equal 'STIDocumentFile', user.file.type
+    assert user.file.is_a?(DocumentFile)
+  end
+
   def test_load_include_from_dataset
     stub_request(:get, 'http://example.com/employees?include=chief&page[per_page]=2')
         .to_return(


### PR DESCRIPTION
The problem was introduced by https://github.com/JsonApiClient/json_api_client/pull/305

When we including the kind of STI resource, we are running in issue with unexpected `type` attribute:

**Given**: resource is kind of 'file' type, with 'type' attribute equals to `STIDocumentFile`
**When**: we including such resource
**Expected**: `parent_resource.file` to be available as usually
**Actual**: the exception raised
```
NoMethodError:
       undefined method `[]' for nil:NilClass
     # /gems/json_api_client-1.12.0/lib/json_api_client/included_data.rb:46:in `record_for'
```

This happens because of

```ruby
module JsonApiClient
  class IncludedData
    def initialize(result_set, data)
       # ...
       # `parameters_from_resource` will override the actual resource `type` value
       # with value from attribute `type`
       params = klass.parser.parameters_from_resource(datum)
       # ...
       # such overridden `type` is used for grouping.
       # i.e. the resources will be grouped by `STIDocumentFile` instead of `file`
       @data = included_set.group_by(&:type)
       # ...
    end
  end
end
```