### PR TITLE
Fix including with blank relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [#350](https://github.com/JsonApiClient/json_api_client/pull/350) - fix resource including with blank `relationships` response data
+
 ## 1.12.1
 
 - [#349](https://github.com/JsonApiClient/json_api_client/pull/349) - fix resource including for STI objects

--- a/lib/json_api_client/resource.rb
+++ b/lib/json_api_client/resource.rb
@@ -546,12 +546,10 @@ module JsonApiClient
         end
       end
 
-      url = relationship_definition["links"]["related"]
-      if relationship_definition["links"] && url
-        return association_for(name).data(url)
-      end
+      return unless links = relationship_definition["links"]
+      return unless url = links["related"]
 
-      nil
+      association_for(name).data(url)
     end
 
     def relation_objects_for(name, relationship_definition)

--- a/test/unit/association_test.rb
+++ b/test/unit/association_test.rb
@@ -896,6 +896,28 @@ class AssociationTest < MiniTest::Test
     assert user.file.is_a?(DocumentFile)
   end
 
+  def test_include_with_blank_relationships
+    stub_request(:get, "http://example.com/document_users/1?include=file")
+        .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
+            data: [
+                {
+                    id: '1',
+                    type: 'document_users',
+                    attributes: {
+                        name: 'John Doe'
+                    },
+                    relationships: {
+                        file: {
+                        }
+                    }
+                }
+            ],
+        }.to_json)
+
+    user = DocumentUser.includes('file').find(1).first
+    assert_nil user.file
+  end
+
   def test_load_include_from_dataset
     stub_request(:get, 'http://example.com/employees?include=chief&page[per_page]=2')
         .to_return(


### PR DESCRIPTION
It fixes the minor breaking change introduced by https://github.com/JsonApiClient/json_api_client/commit/3048ea371e8fc5e5f5b6788c870503c09d2391f4#diff-cd00f457f4dd1dac9e58ef9c63390ca1R514:

**Given**: user = DocumentUser.includes('file').find(1).first
**When**: resource is coming with blank `relationships['file']` json-api data
**Expected**: user.file to be nil
**Actual**: the exception raised

> NoMethodError: undefined method `[]' for nil:NilClass
    json_api_client/lib/json_api_client/resource.rb:549:in `relationship_data_for'