### PR TITLE
Fix resource serialization involving last_result_set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [#351](https://github.com/JsonApiClient/json_api_client/pull/351) - Remove rudimental `last_result_set` relationship from serializer
+
 ## 1.12.2
 
 - [#350](https://github.com/JsonApiClient/json_api_client/pull/350) - fix resource including with blank `relationships` response data

--- a/lib/json_api_client/resource.rb
+++ b/lib/json_api_client/resource.rb
@@ -458,7 +458,6 @@ module JsonApiClient
           self.attributes = updated.attributes
           self.links.attributes = updated.links.attributes
           self.relationships.attributes = updated.relationships.attributes
-          self.relationships.last_result_set = last_result_set
           clear_changes_information
           self.relationships.clear_changes_information
           _clear_cached_relationships
@@ -477,7 +476,6 @@ module JsonApiClient
         false
       else
         mark_as_destroyed!
-        self.relationships.last_result_set = nil
         _clear_cached_relationships
         _clear_belongs_to_params
         true

--- a/test/unit/serializing_test.rb
+++ b/test/unit/serializing_test.rb
@@ -52,6 +52,29 @@ class SerializingTest < MiniTest::Test
     assert_equal expected, resource.first.as_json
   end
 
+  def test_as_json_involving_last_result_set
+    expected = {
+      'type' => 'articles',
+      'id' => '1',
+      'attributes' => {
+        'title' => 'Rails is Omakase'
+      }
+    }
+    stub_request(:post, "http://example.com/articles")
+      .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
+        data: [{
+          type: "articles",
+          id: "1",
+          attributes: {
+            title: "Rails is Omakase"
+          }
+        }]
+      }.to_json)
+
+    resource = Article.create
+    assert_equal expected, resource.as_json
+  end
+
   def test_as_json_api
     expected = {
       'type' => 'articles',


### PR DESCRIPTION
Sometimes `JsonApiClient::Resource` instance evaluates `self.relationships.last_result_set = last_result_set` or `self.relationships.last_result_set = nil`. This behavior was introduced by [performance optimization](https://github.com/stokarenko/json_api_client/commit/3048ea371e8fc5e5f5b6788c870503c09d2391f4#diff-cd00f457f4dd1dac9e58ef9c63390ca1R434) commit.

But we never read the `last_result_set` property on `JsonApiClient::Relationships::Relations` objects, only the writes everywhere. That means that these writes are kind of rudiments.

Even worse, there is no `attr_accessor :last_result_set` defined for `JsonApiClient::Relationships::Relations` class, this way an attempt to write `last_result_set` property triggers `Helpers::DynamicAttributes` routine - `last_result_set` value become to be a part of `attributes` hash, and will be serialized then.

Lets remove rudimental writes to `relationships.last_result_set`. Without this fix the newly added test fails like this:

>  1) Failure:
SerializingTest#test_as_json_involving_last_result_set [/Users/st/dev/ror/everfi/json_api_client/test/unit/serializing_test.rb:75]:
--- expected
+++ actual
@@ -1 +1 @@
-{"type"=>"articles", "id"=>"1", "attributes"=>{"title"=>"Rails is Omakase"}}
+{"id"=>"1", "type"=>"articles", "relationships"=>{"last_result_set"=>{"data"=>[{"type"=>"articles", "id"=>"1"}]}}, "attributes"=>{"title"=>"Rails is Omakase"}}