### PR TITLE
fix missing constant formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [#357](https://github.com/JsonApiClient/json_api_client/pull/357) - fix missing constant formatter
+
 ## 1.14.1
 
 - [#353](https://github.com/JsonApiClient/json_api_client/pull/353) - fix to support deserializing resources with relationships without those related resources being included in the response (issue [#352](https://github.com/JsonApiClient/json_api_client/issues/352)).

--- a/lib/json_api_client.rb
+++ b/lib/json_api_client.rb
@@ -2,6 +2,7 @@ require 'faraday'
 require 'faraday_middleware'
 require 'json'
 require 'addressable/uri'
+require 'json_api_client/formatter'
 
 module JsonApiClient
   autoload :Associations, 'json_api_client/associations'
@@ -9,7 +10,6 @@ module JsonApiClient
   autoload :Connection, 'json_api_client/connection'
   autoload :Errors, 'json_api_client/errors'
   autoload :ErrorCollector, 'json_api_client/error_collector'
-  autoload :Formatter, 'json_api_client/formatter'
   autoload :Helpers, 'json_api_client/helpers'
   autoload :Implementation, 'json_api_client/implementation'
   autoload :IncludedData, 'json_api_client/included_data'


### PR DESCRIPTION
fixes #333

I think we can just require `formatter.rb` instead of auto load it. It will fix all problems with missing contant