### PR TITLE
Support gzip content encoding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,12 @@ matrix:
       gemfile: gemfiles/4.1.gemfile
     - rvm: 2.6.0
       gemfile: gemfiles/4.2.gemfile
+    - rvm: ruby-head
+      gemfile: gemfiles/4.0.gemfile
+    - rvm: ruby-head
+      gemfile: gemfiles/4.1.gemfile
+    - rvm: ruby-head
+      gemfile: gemfiles/4.2.gemfile
 # We need to install latest version of bundler, because one in travis
 # image is too old to recognize platform => :mri_22 in Gemfile.
 before_install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [#359](https://github.com/JsonApiClient/json_api_client/pull/359) - Support gzip content encoding
+
 ## 1.15.0
 
 - [#346](https://github.com/JsonApiClient/json_api_client/pull/346) - add the option to have immutable resources

--- a/lib/json_api_client/connection.rb
+++ b/lib/json_api_client/connection.rb
@@ -14,6 +14,7 @@ module JsonApiClient
         builder.use Middleware::JsonRequest
         builder.use Middleware::Status, status_middleware_options
         builder.use Middleware::ParseJson
+        builder.use ::FaradayMiddleware::Gzip
         builder.adapter(*adapter_options)
       end
       yield(self) if block_given?

--- a/test/unit/connection_test.rb
+++ b/test/unit/connection_test.rb
@@ -15,6 +15,9 @@ class NullParser
   end
 end
 
+class RegularResource < TestResource
+end
+
 class CustomConnectionResource < TestResource
   self.connection_class = NullConnection
   self.parser = NullParser
@@ -69,4 +72,40 @@ class ConnectionTest < MiniTest::Test
     assert_equal proxy.uri.to_s, 'http://proxy.example.com'
   end
 
+  def test_gzipping_without_server_support
+    stub_request(:get, "http://example.com/regular_resources")
+      .with(headers: {'Accept-Encoding'=>'gzip,deflate'})
+      .to_return(
+        status: 200,
+        body: {data: [{id: "1", type: "regular_resources", attributes: {foo: "bar"}}]}.to_json,
+        headers: {content_type: "application/vnd.api+json"}
+      )
+
+    resources = RegularResource.all
+    assert_equal 1, resources.length
+    resource = resources.first
+    assert_equal "bar", resource.foo
+  end
+
+  def test_gzipping_with_server_support
+    io = StringIO.new
+    gz = Zlib::GzipWriter.new(io)
+    gz.write({data: [{id: "1", type: "regular_resources", attributes: {foo: "bar"}}]}.to_json)
+    gz.close
+    body = io.string
+    body.force_encoding('BINARY') if body.respond_to?(:force_encoding)
+
+    stub_request(:get, "http://example.com/regular_resources")
+      .with(headers: {'Accept-Encoding'=>'gzip,deflate'})
+      .to_return(
+        status: 200,
+        body: body,
+        headers: {content_type: "application/vnd.api+json", content_encoding: 'gzip'}
+      )
+
+    resources = RegularResource.all
+    assert_equal 1, resources.length
+    resource = resources.first
+    assert_equal "bar", resource.foo
+  end
 end


### PR DESCRIPTION
Nothing special, just adding `::FaradayMiddleware::Gzip` Faraday middleware in order to take an advantage of Gzipped response body )