### PR TITLE
Relax faraday and faraday_middleware version

### DIFF
--- a/json_api_client.gemspec
+++ b/json_api_client.gemspec
@@ -12,8 +12,8 @@ Gem::Specification.new do |s|
   s.summary = 'Build client libraries compliant with specification defined by jsonapi.org'
 
   s.add_dependency "activesupport", '>= 3.2.0'
-  s.add_dependency "faraday", ['~> 0.15', '>= 0.15.2']
-  s.add_dependency "faraday_middleware", '~> 0.9'
+  s.add_dependency "faraday", '>= 0.15.2', '< 1.2.0'
+  s.add_dependency "faraday_middleware", '>= 0.9.0', '< 1.2.0'
   s.add_dependency "addressable", '~> 2.2'
   s.add_dependency "activemodel", '>= 3.2.0'
   s.add_dependency "rack", '>= 0.2'


### PR DESCRIPTION
Hello!

Faraday and faraday_middleware has recently gone 1.0:

- https://rubygems.org/gems/faraday/versions/1.0.1
- https://rubygems.org/gems/faraday_middleware/versions/1.0.0

We want to upgrade a few gems on our project to the latest version, but found out that there's a dependency conflict because json_api_client has strict faraday and faraday_middleware requirement.

The API hasn't changed much since 0.9 -> 1.0, and the test still pass, so I think we should be good to go.

Please let me know if you have any questions or feedback about this PR. Thank you!