### PR TITLE
bigdecimal 2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 2.4.1
   - 2.5.1
   - 2.6.0
+  - 2.7.1
 env:
   global:
     - CODECLIMATE_REPO_TOKEN=396d4263adb6febf1e6e9b0c0e176fbde35e1a116a3c1ecf8dd4f9384e41979b
@@ -46,6 +47,14 @@ matrix:
     - rvm: 2.6.0
       gemfile: gemfiles/4.1.gemfile
     - rvm: 2.6.0
+      gemfile: gemfiles/4.2.gemfile
+    - rvm: 2.7.1
+      gemfile: gemfiles/3.2.gemfile
+    - rvm: 2.7.1
+      gemfile: gemfiles/4.0.gemfile
+    - rvm: 2.7.1
+      gemfile: gemfiles/4.1.gemfile
+    - rvm: 2.7.1
       gemfile: gemfiles/4.2.gemfile
 # We need to install latest version of bundler, because one in travis
 # image is too old to recognize platform => :mri_22 in Gemfile.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+## 1.17.1
+- [#370](https://github.com/JsonApiClient/json_api_client/pull/370) - bigdecimal 2 support
+
 ## 1.17.0
 
 - [#364](https://github.com/JsonApiClient/json_api_client/pull/364) - Relax faraday and faraday middleware versions

--- a/lib/json_api_client/schema.rb
+++ b/lib/json_api_client/schema.rb
@@ -29,7 +29,7 @@ module JsonApiClient
 
       class Decimal
         def self.cast(value, _)
-          BigDecimal.new(value)
+          BigDecimal(value)
         end
       end
 

--- a/lib/json_api_client/version.rb
+++ b/lib/json_api_client/version.rb
@@ -1,3 +1,3 @@
 module JsonApiClient
-  VERSION = "1.17.0"
+  VERSION = "1.17.1"
 end

--- a/test/unit/coercion_test.rb
+++ b/test/unit/coercion_test.rb
@@ -88,6 +88,6 @@ class CoercionTest < MiniTest::Test
     assert_equal target.integer_me, 2
     assert_equal target.string_me, '1.0'
     assert_equal target.time_me, Time.parse(TIME_STRING)
-    assert_equal target.decimal_me, BigDecimal.new('1.5')
+    assert_equal target.decimal_me, BigDecimal('1.5')
   end
 end


### PR DESCRIPTION
BigDecimal 2.0 no longer supports `.new`.  looks like json_api_client uses both `BigDecimal(x)` and `BigDecimal.new(x)` - mind if we upgrade these last few calls?