### PR TITLE
fix warnings

### DIFF
--- a/lib/json_api_client/query/requestor.rb
+++ b/lib/json_api_client/query/requestor.rb
@@ -10,17 +10,21 @@ module JsonApiClient
 
       # expects a record
       def create(record)
-        request(:post, klass.path(record.path_attributes), {
-            body: { data: record.as_json_api },
-            params: record.request_params.to_params
-        })
+        request(
+          :post,
+          klass.path(record.path_attributes),
+          body: { data: record.as_json_api },
+          params: record.request_params.to_params
+        )
       end
 
       def update(record)
-        request(:patch, resource_path(record.path_attributes), {
-            body: { data: record.as_json_api },
-            params: record.request_params.to_params
-        })
+        request(
+          :patch,
+          resource_path(record.path_attributes),
+          body: { data: record.as_json_api },
+          params: record.request_params.to_params
+        )
       end
 
       def get(params = {})

--- a/test/unit/errors_test.rb
+++ b/test/unit/errors_test.rb
@@ -10,7 +10,7 @@ class ErrorsTest < MiniTest::Test
       User.all
     end
 
-    assert_match /specific message/, err.message
+    assert_match(/specific message/, err.message)
   end
 
   def test_timeout_errors


### PR DESCRIPTION
Ruby 2.7 deprecates automatic conversion from a hash to keyword arguments
https://blog.saeloun.com/2019/10/07/ruby-2-7-keyword-arguments-redesign.html

fixing those up, plus one more I noticed in the logs from https://github.com/JsonApiClient/json_api_client/pull/370#issuecomment-683349721 / https://travis-ci.org/github/JsonApiClient/json_api_client/jobs/722402404

thanks @sharshenov