### PR TITLE
Fix: Cannot access associations of 'dashed' type for a newly initialised resource.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- [#372](https://github.com/JsonApiClient/json_api_client/pull/372) - Fix handling of dashed-types associations correctly
 
 ## 1.17.1
 - [#370](https://github.com/JsonApiClient/json_api_client/pull/370) - bigdecimal 2 support

--- a/lib/json_api_client/associations/base_association.rb
+++ b/lib/json_api_client/associations/base_association.rb
@@ -24,7 +24,7 @@ module JsonApiClient
 
       def load_records(data)
         data.map do |d|
-          record_class = Utils.compute_type(klass, d["type"].classify)
+          record_class = Utils.compute_type(klass, klass.key_formatter.unformat(d["type"]).classify)
           record_class.load id: d["id"]
         end
       end

--- a/lib/json_api_client/associations/has_one.rb
+++ b/lib/json_api_client/associations/has_one.rb
@@ -7,7 +7,7 @@ module JsonApiClient
         end
 
         def load_records(data)
-          record_class = Utils.compute_type(klass, data["type"].classify)
+          record_class = Utils.compute_type(klass, klass.key_formatter.unformat(data["type"]).classify)
           record_class.load id: data["id"]
         end
       end


### PR DESCRIPTION
If you have resource with associations of dashed types. You cannot access those associations because of the bug

```
# {
#   id: 1,
#   type: 'dashed-owners',
#   attributes: {
#     name: "Arjuna"
#   }
# }

class DashedOwner < Formatted
end

class DashedProperty < Formatted
  has_one :dashed_owner
end

dashed_owner = DashedOwner.find(1).first
dashed_property = DashedProperty.new(dashed_owner: dashed_owner)
```

Accessing below will results in following error
```
dashed_property.dashed_owner

NameError: uninitialized constant DashedProperty::Dashed-owner
```