### PR TITLE
Relax faraday dependency to allow 1.3.x

### DIFF
--- a/json_api_client.gemspec
+++ b/json_api_client.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.summary = 'Build client libraries compliant with specification defined by jsonapi.org'
 
   s.add_dependency "activesupport", '>= 3.2.0'
-  s.add_dependency "faraday", '>= 0.15.2', '< 1.2.0'
+  s.add_dependency "faraday", '>= 0.15.2', '< 1.4.0'
   s.add_dependency "faraday_middleware", '>= 0.9.0', '< 1.2.0'
   s.add_dependency "addressable", '~> 2.2'
   s.add_dependency "activemodel", '>= 3.2.0'


### PR DESCRIPTION
👋 Hello, I noticed that this gem only allows Faraday versions `< 1.2.0`. That gem was recently updated to `1.3.0`: https://rubygems.org/gems/faraday/versions/1.3.0

Would you be open to relaxing that requirement to allow the most recent version? The tests still pass for me locally.