### PR TITLE
feat: Add the ability to override getter for JsonApiClient::Resource id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- [378](https://github.com/JsonApiClient/json_api_client/pull/378) - Add the ability to create a subclass of JsonApiClient::Resource to have a modified id method
 
 ## 1.21.0
 - [#395](https://github.com/JsonApiClient/json_api_client/pull/395) - relaxing faraday dependency to anything less than 2.0

--- a/lib/json_api_client/included_data.rb
+++ b/lib/json_api_client/included_data.rb
@@ -24,7 +24,7 @@ module JsonApiClient
       end
 
       grouped_included_set.each do |type, resources|
-        grouped_included_set[type] = resources.index_by(&:id)
+        grouped_included_set[type] = resources.index_by { |resource| resource.attributes[:id] }
       end
 
       @data = grouped_included_set

--- a/test/unit/integer_id_test.rb
+++ b/test/unit/integer_id_test.rb
@@ -2,9 +2,6 @@
 
 require 'test_helper'
 
-##
-# Test checks to see if overriding id as integer
-# prserves the ability to lazy load, or
 class BaseResource < JsonApiClient::Resource
   self.site = 'http://example.com/'
   def id

--- a/test/unit/integer_id_test.rb
+++ b/test/unit/integer_id_test.rb
@@ -22,7 +22,6 @@ class Director < BaseResource
   has_many :movies
 end
 
-
 NUMERIC_ASSERTION = Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.4') ? Fixnum : Integer
 
 class IntegerIdTestAssociationTest < MiniTest::Test

--- a/test/unit/integer_id_test.rb
+++ b/test/unit/integer_id_test.rb
@@ -23,7 +23,8 @@ class Director < BaseResource
 end
 
 class IntegerIdTestAssociationTest < MiniTest::Test
-  def included_document_test_id_from_method_as_integer
+
+  def test_included_document_test_id_from_method_as_integer
     stub_request(:get, 'http://example.com/movies/1?include=actor')
       .to_return(headers: { content_type: 'application/vnd.api+json',
                             accept: 'application/vnd.api+json' },
@@ -69,7 +70,7 @@ class IntegerIdTestAssociationTest < MiniTest::Test
     assert_equal(1, movie.id)
     assert_equal(String, movie.attributes[:id].class)
     assert_equal('1', movie.attributes[:id])
-    assert_equal(Owner, movie.actor.class)
+    assert_equal(Actor, movie.actor.class)
     assert_equal(Integer, movie.actor.id.class)
     assert_equal(1, movie.actor.id)
     assert_equal('1', movie.actor.attributes[:id])

--- a/test/unit/integer_id_test.rb
+++ b/test/unit/integer_id_test.rb
@@ -22,6 +22,9 @@ class Director < BaseResource
   has_many :movies
 end
 
+
+NUMERIC_ASSERTION = Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.4') ? Fixnum : Integer
+
 class IntegerIdTestAssociationTest < MiniTest::Test
 
   def test_included_document_test_id_from_method_as_integer
@@ -66,12 +69,12 @@ class IntegerIdTestAssociationTest < MiniTest::Test
                    ]
                  }.to_json)
     movie = Movie.includes(:actor).find(1).last
-    assert_equal(Integer, movie.id.class)
+    assert_equal(NUMERIC_ASSERTION, movie.id.class)
     assert_equal(1, movie.id)
     assert_equal(String, movie.attributes[:id].class)
     assert_equal('1', movie.attributes[:id])
     assert_equal(Actor, movie.actor.class)
-    assert_equal(Integer, movie.actor.id.class)
+    assert_equal(NUMERIC_ASSERTION, movie.actor.id.class)
     assert_equal(1, movie.actor.id)
     assert_equal('1', movie.actor.attributes[:id])
     assert_equal(movie.actor_id, movie.actor.id)
@@ -107,7 +110,7 @@ class IntegerIdTestAssociationTest < MiniTest::Test
                    }
                  }.to_json)
     movie = Movie.find(1).last
-    assert_equal(Integer, movie.id.class)
+    assert_equal(NUMERIC_ASSERTION, movie.id.class)
     assert_equal(1, movie.id)
     assert_equal(String, movie.attributes[:id].class)
     assert_equal('1', movie.attributes[:id])
@@ -172,7 +175,7 @@ class IntegerIdTestAssociationTest < MiniTest::Test
                    }
                  }.to_json)
     movie = Movie.find(1).last
-    assert_equal(Integer, movie.id.class)
+    assert_equal(NUMERIC_ASSERTION, movie.id.class)
     assert_equal(1, movie.id)
     assert_equal(String, movie.attributes[:id].class)
     assert_equal('1', movie.attributes[:id])

--- a/test/unit/integer_id_test.rb
+++ b/test/unit/integer_id_test.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+##
+# Test checks to see if overriding id as integer
+# prserves the ability to lazy load, or
+class BaseResource < JsonApiClient::Resource
+  self.site = 'http://example.com/'
+  def id
+    attributes[:id].to_i if attributes[:id].present?
+  end
+end
+
+class Actor < BaseResource
+  has_many :movies
+end
+
+class Movie < BaseResource
+  belongs_to :actor, shallow_path: true
+  has_one :director, shallow_path: true
+end
+
+class Director < BaseResource
+  has_many :movies
+end
+
+class IntegerIdTestAssociationTest < MiniTest::Test
+  def included_document_test_id_from_method_as_integer
+    stub_request(:get, 'http://example.com/movies/1?include=actor')
+      .to_return(headers: { content_type: 'application/vnd.api+json',
+                            accept: 'application/vnd.api+json' },
+                 body: {
+                   data: {
+                     id: '1',
+                     type: 'movie',
+                     attributes: {
+                       actor_id: 1,
+                       director_id: 1,
+                       created_at: '2021-04-20T17:27:06-07:00',
+                       updated_at: '2021-04-20T17:27:07-07:00'
+                     },
+                     relationships: {
+                       actor: {
+                         data: {
+                           id: '1',
+                           type: 'actor'
+                         }
+                       },
+                       director: {
+                         data: {
+                           id: '1',
+                           type: 'director'
+                         }
+                       }
+                     }
+                   },
+                   included: [
+                     {
+                       id: '1',
+                       type: 'actor',
+                       attributes: {
+                         name: 'Keanu',
+                         updated_at: '2021-04-22T13:50:19-07:00',
+                         created_at: '2021-04-19T16:20:13-07:00'
+                       }
+                     }
+                   ]
+                 }.to_json)
+    movie = Movie.includes(:actor).find(1).last
+    assert_equal(Integer, movie.id.class)
+    assert_equal(1, movie.id)
+    assert_equal(String, movie.attributes[:id].class)
+    assert_equal('1', movie.attributes[:id])
+    assert_equal(Owner, movie.actor.class)
+    assert_equal(Integer, movie.actor.id.class)
+    assert_equal(1, movie.actor.id)
+    assert_equal('1', movie.actor.attributes[:id])
+    assert_equal(movie.actor_id, movie.actor.id)
+  end
+
+  def test_not_included_data_document
+    stub_request(:get, 'http://example.com/movies/1')
+      .to_return(headers: { content_type: 'application/vnd.api+json',
+                            accept: 'application/vnd.api+json' },
+                 body: {
+                   data: {
+                     id: '1',
+                     type: 'movie',
+                     attributes: {
+                       actor_id: 1,
+                       created_at: '2021-04-20T17:27:06-07:00',
+                       updated_at: '2021-04-20T17:27:07-07:00'
+                     },
+                     relationships: {
+                       actor: {
+                         data: {
+                           id: '1',
+                           type: 'actor'
+                         },
+                         director: {
+                           data: {
+                             id: '1',
+                             type: 'director'
+                           }
+                         }
+                       }
+                     }
+                   }
+                 }.to_json)
+    movie = Movie.find(1).last
+    assert_equal(Integer, movie.id.class)
+    assert_equal(1, movie.id)
+    assert_equal(String, movie.attributes[:id].class)
+    assert_equal('1', movie.attributes[:id])
+    assert_nil(movie.actor)
+  end
+
+  def test_not_included_data_document_with_relationships_links
+    stub_request(:get, 'http://example.com/movies/1')
+      .to_return(headers: { content_type: 'application/vnd.api+json',
+                            accept: 'application/vnd.api+json' },
+                 body: {
+                   data: {
+                     id: '1',
+                     type: 'movie',
+                     attributes: {
+                       actor_id: 1,
+                       created_at: '2021-04-20T17:27:06-07:00',
+                       updated_at: '2021-04-20T17:27:07-07:00'
+                     },
+                     relationships: {
+                       actor: {
+                         links: {
+                           self: '/movies/1',
+                           related: '/actors/1'
+                         }
+                       },
+                       director: {
+                         links: {
+                           self: '/movies/1',
+                           related: '/directors/1'
+                         }
+                       }
+                     }
+                   }
+                 }.to_json)
+    stub_request(:get, 'http://example.com/directors/1')
+      .to_return(headers: { content_type: 'application/vnd.api+json',
+                            accept: 'application/vnd.api+json' },
+                 body: {
+                   data: {
+                     id: '1',
+                     type: 'movie',
+                     attributes: {
+                       actor_id: 1,
+                       created_at: '2021-04-20T17:27:06-07:00',
+                       updated_at: '2021-04-20T17:27:07-07:00'
+                     },
+                     relationships: {
+                       actor: {
+                         links: {
+                           self: '/movies/1',
+                           related: '/actors/1'
+                         }
+                       },
+                       director: {
+                         links: {
+                           self: '/movies/1',
+                           related: '/directors/1'
+                         }
+                       }
+                     }
+                   }
+                 }.to_json)
+    movie = Movie.find(1).last
+    assert_equal(Integer, movie.id.class)
+    assert_equal(1, movie.id)
+    assert_equal(String, movie.attributes[:id].class)
+    assert_equal('1', movie.attributes[:id])
+    assert_equal(Director, movie.director.class)
+  end
+end


### PR DESCRIPTION
Hello, I just want to ask and see if we can modify a single line in one file ```included_data.rb```. I ran into an issue needing to add a method id that will normalize the raw ids into integers, in cases of belongs_to, relationships.  Please see test file [here](https://github.com/JsonApiClient/json_api_client/pull/378/files#diff-80ebf7f95a92f4b80c2d68d01a357a4c393391ebe365649aa7e45da9ffc62da5R10).

**Desired Functionality:**
  I want to be able create a base class that overrides the id method of a resource and consistently return it as an integer.  Because I want to be able to transform back, the original type of my resource id.

This happens when we serialize active record / application record objects from mysql through json-apiserializer gem.
Their representation of id's turn into strings, that's how the json api documentation declares it so.

There seems to be only a one-liner change so that we can override the id method of a JsonApiClient::Resource

This adds the ability to create a subclass of JsonApiClient::Resource to have a modified id method that returns the id as an integer.  This gives the application code the flexibility to match against attributes (ids of type integer) of other resources that are integers, which weren't translated to strings, (from gems such as json-apiserializer).