### PR TITLE
adding Pry as a development dependency

### DIFF
--- a/json_api_client.gemspec
+++ b/json_api_client.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "webmock", '~> 3.5.1'
   s.add_development_dependency "mocha"
+  s.add_development_dependency "pry"
 
   s.license = "MIT"
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,7 @@ require 'minitest/autorun'
 require 'webmock/minitest'
 require 'mocha/minitest'
 require 'pp'
+require 'pry'
 
 # shim for ActiveSupport 4.0.x requiring minitest 4.2
 unless defined?(Minitest::Test)


### PR DESCRIPTION
adding Pry as a development dependency, to make local development for contributors easier.

Having this `development_dependency` does not impact any of the downstream projects of the `json_api_client` gem, 
it just sets contributors up to be able to set breakpoints in the code via `binding.pry`, so they can debug tests.

It would be great to have this set up out-of-the-box, so that when people want to contribute, they can easily set breakpoints.