### PR TITLE
Rework Errors::NotFound

### DIFF
--- a/lib/json_api_client/errors.rb
+++ b/lib/json_api_client/errors.rb
@@ -46,11 +46,14 @@ module JsonApiClient
 
     class NotFound < ClientError
       attr_reader :uri
-      def initialize(uri)
-        @uri = uri
-
-        msg = "Resource not found: #{uri.to_s}"
-        super nil, msg
+      def initialize(env_or_uri, msg = nil)
+        if env_or_uri.kind_of?(Faraday::Env)
+          super env_or_uri, msg
+        else
+          @uri = env_or_uri
+          msg ||= "Couldn't find resource at: #{uri.to_s}"
+          super env_or_uri, msg
+        end
       end
     end
 

--- a/lib/json_api_client/middleware/status.rb
+++ b/lib/json_api_client/middleware/status.rb
@@ -37,7 +37,10 @@ module JsonApiClient
         when 403
           raise Errors::AccessDenied, env
         when 404
-          raise Errors::NotFound, env[:url]
+          raise Errors::NotFound.new(
+            env,
+            "Couldn't find resource at: #{env[:url]}"
+          )
         when 408
           raise Errors::RequestTimeout, env
         when 409

--- a/test/unit/errors_test.rb
+++ b/test/unit/errors_test.rb
@@ -65,12 +65,12 @@ class ErrorsTest < MiniTest::Test
       .to_return(
         headers: {content_type: "application/vnd.api+json"},
         status: 404,
-        body: {errors: [{title: "Resource not found"}]}.to_json
+        body: {errors: [{title: "Not found"}]}.to_json
       )
 
     exception = assert_raises(JsonApiClient::Errors::NotFound) { User.all }
     assert_equal(
-      'http://example.com/users (Resource not found)',
+      "Couldn't find resource at: http://example.com/users (Not found)",
       exception.message
     )
   end

--- a/test/unit/errors_test.rb
+++ b/test/unit/errors_test.rb
@@ -60,13 +60,34 @@ class ErrorsTest < MiniTest::Test
     assert_equal '503 Service Unavailable (Timeout error)', exception.message
   end
 
-  def test_not_found
+  def test_not_found_with_json_api_response
     stub_request(:get, "http://example.com/users")
-      .to_return(status: 404, body: "something irrelevant")
+      .to_return(
+        headers: {content_type: "application/vnd.api+json"},
+        status: 404,
+        body: {errors: [{title: "Resource not found"}]}.to_json
+      )
 
-    assert_raises JsonApiClient::Errors::NotFound do
-      User.all
-    end
+    exception = assert_raises(JsonApiClient::Errors::NotFound) { User.all }
+    assert_equal(
+      'http://example.com/users (Resource not found)',
+      exception.message
+    )
+  end
+
+  def test_not_found_errors_with_plain_text_response
+    stub_request(:get, "http://example.com/users")
+      .to_return(
+        headers: {content_type: "text/plain"},
+        status: 404,
+        body: "resource not found"
+      )
+
+    exception = assert_raises(JsonApiClient::Errors::NotFound) { User.all }
+    assert_equal(
+      "Couldn't find resource at: http://example.com/users",
+      exception.message
+    )
   end
 
   def test_conflict


### PR DESCRIPTION
We don't currently pass the Faraday environment when raising a `NotFound`
exception in the `Status` middleware. This is inconsistent with other types of
errors that inherit from `ApiError` and causes us to lose any JSON API errors
that might be present in the environment.

This change reworks the `NotFound` exception constructor such that it accepts
a Faraday::Env and an optional message. If an environment is passed and a
`msg` is not, it sets a message using `environment[:url]` to maintain previous 
messaging. However, it passes along the environment to the `super` call such 
that we can supplement the messaging with the JSON API error message 
handling implemented on `ApiError`.

If the first argument provided to the constructor is anything other than a
`Faraday::Env`, then the previous behavior is provided.