### PR TITLE
Allow Faraday dependency up to v2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem 'rake'
+gem 'rdoc'
 gem 'appraisal'
 
 gem "activesupport"

--- a/json_api_client.gemspec
+++ b/json_api_client.gemspec
@@ -12,8 +12,8 @@ Gem::Specification.new do |s|
   s.summary = 'Build client libraries compliant with specification defined by jsonapi.org'
 
   s.add_dependency "activesupport", '>= 3.2.0'
-  s.add_dependency "faraday", '>= 0.15.2', '< 1.2.0'
-  s.add_dependency "faraday_middleware", '>= 0.9.0', '< 1.2.0'
+  s.add_dependency "faraday", '>= 0.15.2', '< 2.0'
+  s.add_dependency "faraday_middleware", '>= 0.9.0', '< 2.0'
   s.add_dependency "addressable", '~> 2.2'
   s.add_dependency "activemodel", '>= 3.2.0'
   s.add_dependency "rack", '>= 0.2'


### PR DESCRIPTION
This PR closes #394 and allows Faraday versions up to v2.0