### PR TITLE
Fixes #390: serialization issue for relationships

### DIFF
--- a/lib/json_api_client/resource.rb
+++ b/lib/json_api_client/resource.rb
@@ -365,11 +365,6 @@ module JsonApiClient
 
       setup_default_properties
 
-      self.class.associations.each do |association|
-        if params.has_key?(association.attr_name.to_s)
-          set_attribute(association.attr_name, params[association.attr_name.to_s])
-        end
-      end
       self.request_params = self.class.request_params_class.new(self.class)
     end
 

--- a/test/unit/resource_test.rb
+++ b/test/unit/resource_test.rb
@@ -88,6 +88,7 @@ class ResourceTest < MiniTest::Test
     assert_equal(article.foo, 'bar')
     assert_equal({'type' => 'authors', 'id' => 1}, article.relationships.author)
     assert article.relationships.attribute_changed?(:author)
+    refute article.attributes.has_key?(:author)
   end
 
   def test_default_params_overrideable


### PR DESCRIPTION
According to the jsonapi specification https://jsonapi.org/format/#document-resource-object-attributes
attributes MUST NOT contain a relationship member.

There's a serialization issue introduced with Pull request #386 as described in issue #390.