### PR TITLE
fix: Multi-word custom endpoint not respecting route format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+## 1.22.0
+- [#400](https://github.com/JsonApiClient/json_api_client/pull/400) - Fix for multi-word custom endpoint and route format
+
 ## 1.21.1
 - [#404](https://github.com/JsonApiClient/json_api_client/pull/404) - Expose NotFound json errors
 - [#378](https://github.com/JsonApiClient/json_api_client/pull/378) - Add the ability to create a subclass of JsonApiClient::Resource to have a modified id method

--- a/lib/json_api_client/resource.rb
+++ b/lib/json_api_client/resource.rb
@@ -260,10 +260,11 @@ module JsonApiClient
         metaclass = class << self
           self
         end
+        endpoint_name = _name_for_route_format(name)
         metaclass.instance_eval do
           define_method(name) do |*params|
             request_params = params.first || {}
-            requestor.custom(name, options, request_params)
+            requestor.custom(endpoint_name, options, request_params)
           end
         end
       end
@@ -274,10 +275,11 @@ module JsonApiClient
       # @param options [Hash] endpoint options
       # @option options [Symbol] :request_method The request method (:get, :post, etc)
       def member_endpoint(name, options = {})
+        endpoint_name = self._name_for_route_format(name)
         define_method name do |*params|
           request_params = params.first || {}
           request_params[self.class.primary_key] = attributes.fetch(self.class.primary_key)
-          self.class.requestor.custom(name, options, request_params)
+          self.class.requestor.custom(endpoint_name, options, request_params)
         end
       end
 
@@ -346,6 +348,17 @@ module JsonApiClient
         return connection_object unless connection_object.nil? || rebuild
         self.connection_object = connection_class.new(connection_options.merge(site: site)).tap do |conn|
           yield(conn) if block_given?
+        end
+      end
+
+      def _name_for_route_format(name)
+        case self.route_format
+        when :dasherized_route
+          name.to_s.dasherize
+        when :camelized_route
+          name.to_s.camelize(:lower)
+        else
+          name
         end
       end
     end

--- a/test/unit/custom_endpoint_test.rb
+++ b/test/unit/custom_endpoint_test.rb
@@ -7,6 +7,24 @@ class Country < TestResource
 
 end
 
+class Pet < TestResource
+  self.site = "http://example.com/"
+  self.route_format = :dasherized_route
+
+  custom_endpoint :related_pets, on: :member, request_method: :get
+  custom_endpoint :vip_pets, on: :collection, request_method: :get
+
+end
+
+class MythicBeasts < TestResource
+  self.site = "http://example.com/"
+  self.route_format = :camelized_route
+
+  custom_endpoint :related_beasts, on: :member, request_method: :get
+  custom_endpoint :ancient_beasts, on: :collection, request_method: :get
+
+end
+
 class CustomEndpointTest < MiniTest::Test
 
   def test_collection_get
@@ -41,6 +59,74 @@ class CustomEndpointTest < MiniTest::Test
 
   def test_collection_methods_should_not_add_methods_to_all_classes
     assert !Class.respond_to?(:autocomplete), "adding a custom method should not add methods to all classes"
+  end
+
+  def test_member_dasherized_route_format_converts_custom_endpoint
+    stub_request(:get, "http://example.com/pets/1/related-pets")
+      .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
+        data: [
+          {id: 1, type: 'pets'},
+          {id: 2, type: 'pets'},
+        ]
+      }.to_json)
+
+    pet = Pet.new({id: 1, name: 'Otto'})
+    pet.mark_as_persisted!
+
+    related_pets = pet.related_pets
+
+    assert_equal 2, related_pets.length
+    assert_equal [1,2], related_pets.map(&:id)
+  end
+
+  def test_collection_dasherized_route_format_converts_custom_endpoint
+    stub_request(:get, "http://example.com/pets/vip-pets")
+      .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
+        data: [
+          {id: 4, type: 'pets'},
+          {id: 5, type: 'pets'},
+          {id: 6, type: 'pets'}
+        ]
+      }.to_json)
+
+      vip_pets = Pet.vip_pets
+
+      assert_equal 3, vip_pets.length
+      assert_equal [4,5,6], vip_pets.map(&:id)
+  end
+
+  def test_member_camelized_route_format_converts_custom_endpoint
+    stub_request(:get, "http://example.com/mythicBeasts/1/relatedBeasts")
+      .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
+        data: [
+          {id: 1, type: 'mythic-beasts'},
+          {id: 2, type: 'mythic-beasts'},
+        ]
+      }.to_json)
+
+    dragon = MythicBeasts.new({id: 1, name: 'Dragon'})
+    dragon.mark_as_persisted!
+
+    related_beasts = dragon.related_beasts
+
+    assert_equal 2, related_beasts.length
+    assert_equal [1,2], related_beasts.map(&:id)
+  end
+
+  def test_collection_camelized_route_format_converts_custom_endpoint
+    stub_request(:get, "http://example.com/mythicBeasts/ancientBeasts")
+      .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
+        data: [
+          {id: 4, type: 'mythic-beasts'},
+          {id: 5, type: 'mythic-beasts'},
+          {id: 6, type: 'mythic-beasts'}
+        ]
+      }.to_json)
+
+      ancient_beasts = MythicBeasts.ancient_beasts
+
+      assert_equal 3, ancient_beasts.length
+      assert_equal [4,5,6], ancient_beasts.map(&:id)
   end
 
 end


### PR DESCRIPTION
This PR fixes an issue I experienced when working with multi-word custom endpoints. If you have a multi-word custom endpoint and you also have the `self.route_format = :dasherized_route` config in your base class, upon calling that `custom_endpoint` JsonApiClient doesn't respect the configuration selected and will use the underscored version of the endpoint name.

For instance:

Given,

```ruby
class Pet < TestResource
  self.site = "http://example.com/"
  self.route_format = :dasherized_route

  custom_endpoint :related_pets, on: :member, request_method: :get
  custom_endpoint :vip_pets, on: :collection, request_method: :get
end
```

When calling `Pet.vip_pets` or `pet = Pet.new(...); pet.related_pets` the resulting endpoint being called will be either:
`http://example.com/pets/vip_pets` or `http://example.com/pets/:id/related_pets`

instead of `http://example.com/pets/vip-pets` or `http://example.com/pets/:id/related-pets`

Same issue applies for `camelized_routes`.

This PR fixes this by checking the `route_format` configuration attribute and making sure it is converted to the appropriate endpoint name, using `ActiveSupport` helper methods.

The methods defined in the instance of the class will still be underscored, so that we can still do `Pet.vip_vets`.

Happy to address any concerns or comments, thanks!