### PR TITLE
Remove depredated faraday_middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [#402](https://github.com/JsonApiClient/json_api_client/pull/402) - Remove deprecated faraday_middleware and add faraday-gzip
+
 ## 1.21.0
 - [#395](https://github.com/JsonApiClient/json_api_client/pull/395) - relaxing faraday dependency to anything less than 2.0
 

--- a/json_api_client.gemspec
+++ b/json_api_client.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "activesupport", '>= 3.2.0'
   s.add_dependency "faraday", '>= 0.15.2', '< 2.0'
-  s.add_dependency "faraday_middleware", '>= 0.9.0', '< 2.0'
+  s.add_dependency "faraday-gzip", '>= 0.1.0', '< 2.0'
   s.add_dependency "addressable", '~> 2.2'
   s.add_dependency "activemodel", '>= 3.2.0'
   s.add_dependency "rack", '>= 0.2'

--- a/lib/json_api_client.rb
+++ b/lib/json_api_client.rb
@@ -1,5 +1,5 @@
 require 'faraday'
-require 'faraday_middleware'
+require 'faraday/gzip'
 require 'json'
 require 'addressable/uri'
 require 'json_api_client/formatter'

--- a/lib/json_api_client/connection.rb
+++ b/lib/json_api_client/connection.rb
@@ -14,7 +14,7 @@ module JsonApiClient
         builder.use Middleware::JsonRequest
         builder.use Middleware::Status, status_middleware_options
         builder.use Middleware::ParseJson
-        builder.use ::FaradayMiddleware::Gzip
+        builder.use ::Faraday::Gzip::Middleware
         builder.adapter(*adapter_options)
       end
       yield(self) if block_given?


### PR DESCRIPTION
## Description

Faraday Middleware is [now deprecated](https://github.com/lostisland/faraday_middleware#%EF%B8%8F-deprecation-warning-%EF%B8%8F).

Replace deprecated gzip middleware for [faraday-gzip middleware](https://rubygems.org/gems/faraday-gzip) 