### PR TITLE
feat: Use the association options to lookup relationship class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+## 1.23.0
+- [#403](https://github.com/JsonApiClient/json_api_client/pull/403) - Feature: Use the association options to lookup relationship class
+
 ## 1.21.1
 - [#404](https://github.com/JsonApiClient/json_api_client/pull/404) - Expose NotFound json errors
 - [#378](https://github.com/JsonApiClient/json_api_client/pull/378) - Add the ability to create a subclass of JsonApiClient::Resource to have a modified id method

--- a/lib/json_api_client/utils.rb
+++ b/lib/json_api_client/utils.rb
@@ -7,6 +7,11 @@ module JsonApiClient
       # the type_name is an absolute reference.
       return type_name.constantize if type_name.match(/^::/)
 
+      # Check the klass association definitions
+      association_klass_match = klass.associations.find { |a| a.attr_name.to_s.singularize == type_name.underscore }
+      association_klass = association_klass_match.options[:class] if association_klass_match
+      return association_klass if association_klass
+
       # Build a list of candidates to search for
       candidates = []
       klass.name.scan(/::|$/) { candidates.unshift "#{$`}::#{type_name}" }


### PR DESCRIPTION
Hey there,

I'm opening this PR because I noticed an issue with the way the association class types are being looked up when including related resources.

I discovered this when having cross-referenced types when using namespaces, like the example suggests:
```ruby
module CrossNamespaceTwo
  class Nail < TestResource
    property :size
  end
end

module CrossNamespaceOne
  class Hammer < TestResource
    property :brand

    has_many :nails, class: CrossNamespaceTwo::Nail
  end
end
```

In this case whenever the IncludedData class was initializing an instance, the utils class would not be able to produce a correct type to use for the related included type producing an error similar to the following:
```
Finished in 0.447569s, 538.4645 runs/s, 1619.8620 assertions/s.

  1) Error:
AssociationTest#test_cross_namespace_resource_references:
NameError: uninitialized constant CrossNamespaceOne::Hammer::Nail
```

Since one should be able to add options to the association definition the `class` option makes sense here. This PR makes use of that to try and figure out the appropriate type before defaulting to the existing behavior.

Thanks in advance for taking a look!