### PR TITLE
Deep-merge nested additional_params (i.e. chained use of `with_params` with nested arguments)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [#406](https://github.com/JsonApiClient/json_api_client/pull/406) - Deep-merge nested `additional_params`
+
 ## 1.21.1
 - [#404](https://github.com/JsonApiClient/json_api_client/pull/404) - Expose NotFound json errors
 - [#378](https://github.com/JsonApiClient/json_api_client/pull/378) - Add the ability to create a subclass of JsonApiClient::Resource to have a modified id method

--- a/lib/json_api_client/query/builder.rb
+++ b/lib/json_api_client/query/builder.rb
@@ -136,7 +136,7 @@ module JsonApiClient
              primary_key:       opts.fetch( :primary_key, @primary_key ),
              pagination_params: @pagination_params.merge( opts.fetch( :pagination_params, {} ) ),
              path_params:       @path_params.merge( opts.fetch( :path_params, {} ) ),
-             additional_params: @additional_params.merge( opts.fetch( :additional_params, {} ) ),
+             additional_params: @additional_params.deep_merge( opts.fetch( :additional_params, {} ) ),
              filters:           @filters.merge( opts.fetch( :filters, {} ) ),
              includes:          @includes + opts.fetch( :includes, [] ),
              orders:            @orders + opts.fetch( :orders, [] ),

--- a/test/unit/query_builder_test.rb
+++ b/test/unit/query_builder_test.rb
@@ -122,6 +122,16 @@ class QueryBuilderTest < MiniTest::Test
     Article.with_params(sort: "foo").to_a
   end
 
+  def test_can_merge_nested_additional_params
+    stub_request(:get, "http://example.com/articles")
+      .with(query: {top: {foos: 1, bars: 2}})
+      .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
+        data: []
+      }.to_json)
+
+    Article.with_params(top: {foos: 1}).with_params(top: {bars: 2}).to_a
+  end
+
   def test_can_select_fields
     stub_request(:get, "http://example.com/articles")
       .with(query: {fields: {articles: 'title,body'}})


### PR DESCRIPTION
Before, calling:

```
Article.with_params(top: {foos: 1}).with_params(top: {bars: 2})
```

Would trigger a query:

```
.with(query: {top: {bars: 2}})
```

(i.e. the `foos: 1` vanished), because the code was calling `merge` on the parameters. In other words, it was doing:

```
{top: {foos: 1}}.merge(top: {bars: 2})
=> {:top=>{:bars=>2}}
```

With this fix, the builder correctly merges _nested_ parameters:

```
{top: {foos: 1}}.deep_merge(top: {bars: 2})
=> {:top=>{:foos => 1, :bars=>2}}
```